### PR TITLE
Fullscreen sim with visible controls (v1)

### DIFF
--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -1,0 +1,190 @@
+/// <reference path="./svg.ts" />
+
+namespace pxsim {
+    import s = svgUtil;
+
+    const COMPONENT_WIDTH = 60;
+    const DRAW_UNIT = COMPONENT_WIDTH / 3;
+    const PADDING = 30;
+
+    const D_PAD_COLOR = "#dedede";
+    const D_PAD_DOWN_COLOR = "#f4b342";
+
+    const BUTTON_COLOR = "#66bb77";
+    const BUTTON_DOWN_COLOR = "#225533";
+
+    const aspectRatio = 2; // width / height
+    
+    export class ControlPad {
+        root: s.SVG;
+
+        protected dPad: s.Group;
+        protected buttons: s.Group;
+
+        protected up: s.Rect;
+        protected down: s.Rect;
+        protected left: s.Rect;
+        protected right: s.Rect;
+
+        protected primary: s.Circle;
+        protected secondary: s.Circle;
+
+        constructor(parent: Element) {
+            this.root = new s.SVG(parent);
+            this.buildDom();
+        }
+
+        public mirrorKey(key: Key, down: boolean, realEvent?: boolean) {
+            switch (key) {
+                case Key.Up:
+                    this.setDpadState(this.up, down);
+                    break;
+                case Key.Right:
+                    this.setDpadState(this.right, down);
+                    break;
+                case Key.Down:
+                    this.setDpadState(this.down, down);
+                    break;
+                case Key.Left:
+                    this.setDpadState(this.left, down);
+                    break;
+                case Key.A:
+                    this.setButtonState(this.primary, down);
+                    break;
+                case Key.B:
+                    this.setButtonState(this.secondary, down);
+                    break;
+            }
+        }
+
+        protected buildDom() {
+            this.drawDirectionalPad();
+            this.drawButtonGroup();
+
+            const height = COMPONENT_WIDTH + PADDING * 2;
+            const width = height * aspectRatio;
+
+            this.dPad.translate(PADDING, PADDING);
+            this.buttons.translate(width - PADDING - COMPONENT_WIDTH, PADDING);
+
+            this.root.setAttribute("height", height).setAttribute("width", width);
+        }
+
+
+        protected drawDirectionalPad() {
+            this.dPad = this.root.group();
+            
+            this.dPad.draw("polygon")
+                .at(0, 0)
+                .fill(D_PAD_COLOR)
+                .stroke("black", 4)
+                .setAttribute("stroke-linejoin", "round")
+                .with(scale([
+                    { x: 1, y: 0 },
+                    { x: 2, y: 0 },
+                    { x: 2, y: 1 },
+                    { x: 3, y: 1 },
+                    { x: 3, y: 2 },
+                    { x: 2, y: 2 },
+                    { x: 2, y: 3 },
+                    { x: 1, y: 3 },
+                    { x: 1, y: 2 },
+                    { x: 0, y: 2 },
+                    { x: 0, y: 1 },
+                    { x: 1, y: 1 }
+                ], DRAW_UNIT));
+
+            // Draw the real touch pads
+            this.up = this.drawTouchPad(this.dPad, DRAW_UNIT, 0);
+            this.bindPadEvents(this.up, Key.Up);
+
+            this.right = this.drawTouchPad(this.dPad, 2 * DRAW_UNIT, DRAW_UNIT);
+            this.bindPadEvents(this.right, Key.Right);
+
+            this.down = this.drawTouchPad(this.dPad, DRAW_UNIT, 2 * DRAW_UNIT);
+            this.bindPadEvents(this.down, Key.Down);
+
+            this.left = this.drawTouchPad(this.dPad, 0, DRAW_UNIT);
+            this.bindPadEvents(this.left, Key.Left);
+
+            // Add some helpful diagonal touch pads
+            this.bindPadEvents(this.drawTouchPad(this.dPad, 0, 0), [Key.Up, Key.Left]);
+            this.bindPadEvents(this.drawTouchPad(this.dPad, 2 * DRAW_UNIT, 0), [Key.Up, Key.Right]);
+            this.bindPadEvents(this.drawTouchPad(this.dPad, 0, 2 * DRAW_UNIT), [Key.Down, Key.Left]);
+            this.bindPadEvents(this.drawTouchPad(this.dPad, 2 * DRAW_UNIT, 2 * DRAW_UNIT), [Key.Down, Key.Right]);
+        }
+
+        protected drawTouchPad(parent: s.Group, x: number, y: number, width = DRAW_UNIT, height = DRAW_UNIT) {
+            const pad: s.Rect = parent.draw("rect")
+                .at(x, y)
+                .fill(D_PAD_COLOR, 0)
+                .size(width, height);
+            return pad;
+        }
+
+        protected bindPadEvents(pad: s.Rect, target: Key | Key[]) {
+            const down = Array.isArray(target) ? 
+                () => target.forEach(key => board().handleKeyEvent(key, true)) :
+                () => board().handleKeyEvent(target, true);
+            
+            const up = Array.isArray(target) ? 
+                () => target.forEach(key => board().handleKeyEvent(key, false)) :
+                () => board().handleKeyEvent(target, false);
+            
+            pad.onDown(down);
+            pad.onLeave(up);
+            pad.onUp(up);
+            pad.onEnter(isDown => isDown ? down() : up());
+        }
+
+        protected drawButtonGroup() {
+            this.buttons = this.root.group();
+
+            this.primary = this.drawButton("A", 2.5 * DRAW_UNIT, DRAW_UNIT, Key.A);
+            this.secondary = this.drawButton("B", 0.75 * DRAW_UNIT, 2.5 * DRAW_UNIT, Key.B);
+        }
+
+        protected drawButton(symbol: string, cx: number, cy: number, key: Key) {
+            const r = DRAW_UNIT * 0.75;
+
+            const button: s.Circle = this.buttons.draw("circle")
+                .at(cx, cy)
+                .radius(r)
+                .fill(BUTTON_COLOR)
+                .stroke(BUTTON_DOWN_COLOR, 2);
+            
+            this.buttons.draw("text")
+                .at(cx, cy)
+                .text(symbol)
+                .fill("white")
+                .anchor("middle")
+                .alignmentBaseline("middle");
+
+            this.bindPadEvents(this.drawTouchPad(this.buttons, cx - r, cy - r, r * 2, r * 2), key);
+
+            return button;
+        }
+
+        protected setDpadState(pad: s.Rect, down: boolean) {
+            if (down) {
+                pad.fill(D_PAD_DOWN_COLOR, 1);
+            }
+            else {
+                pad.fill(D_PAD_COLOR, 0);
+            }
+        }
+
+        protected setButtonState(button: s.Circle, down: boolean) {
+            if (down) {
+                button.fill(BUTTON_DOWN_COLOR).stroke(BUTTON_COLOR);
+            }
+            else {
+                button.fill(BUTTON_COLOR).stroke(BUTTON_DOWN_COLOR);
+            }
+        }
+    }
+
+    function scale(points: { x: number, y: number } [], factor: number) {
+        return points.map(({ x, y }) => ({ x: x * factor, y: y * factor }))
+    }
+}

--- a/sim/public/sim.css
+++ b/sim/public/sim.css
@@ -1,11 +1,8 @@
 body {
     font-size: 12px;
     color: white;
+    height: 100vh;
     font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace
-}
-
-svg {
-    width:100%;
 }
 
 .sprite {
@@ -20,7 +17,38 @@ canvas {
 	image-rendering: -webkit-optimize-contrast;
 	image-rendering: optimize-contrast;
 	image-rendering: pixelated;
-	-ms-interpolation-mode: nearest-neighbor;
+    -ms-interpolation-mode: nearest-neighbor;
+}
+
+#screen {
+    display: flex;
+    flex-direction: column;
+    align-content: center;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+}
+
+#paint-surface {
+    object-fit: contain;
+    display: inline;
+    height: 100%;
+}
+
+#paint-surface-container {
+    width: 100%;
+    flex: 5;
+    text-align: center;
+}
+
+#debug-stats {
+    position: absolute;
+    top: 90%;
+    left: 0;
+}
+
+#controls {
+    flex: 1;
 }
 
 .stats {

--- a/sim/public/simulator.html
+++ b/sim/public/simulator.html
@@ -17,5 +17,13 @@
 </head>
 
 <body id="root" class="blur">
+    <div id="debug-stats"></div>
+    <div id="screen">
+        <div id="paint-surface-container">
+            <canvas id="paint-surface"></canvas>
+        </div>
+        <div id="controls"></div>
+    </div>
+    <div id="instructions"></div>
 </body>
 </html>

--- a/sim/svg.ts
+++ b/sim/svg.ts
@@ -1,0 +1,665 @@
+namespace svgUtil {
+    export type Map<T> = {
+        [index: string]: T;
+    };
+
+    export type PointerHandler = () => void;
+
+    export enum PatternUnits {
+        userSpaceOnUse = 0,
+        objectBoundingBox = 1,
+    }
+
+    export class BaseElement<T extends SVGElement> {
+        el: T;
+        constructor(type: string) {
+            this.el = elt(type) as T;
+        }
+        attr(attributes: Map<string | number | boolean>): this {
+            for (const at in attributes) {
+                this.setAttribute(at, attributes[at]);
+            }
+            return this;
+        }
+
+        setAttribute(name: string, value: string | number | boolean): this {
+            this.el.setAttribute(name, value.toString());
+            return this;
+        }
+
+        id(id: string): this {
+            return this.setAttribute("id", id);
+        }
+    }
+
+    export class DrawContext<T extends SVGElement> extends BaseElement<T> {
+        draw(type: "text"): Text;
+        draw(type: "circle"): Circle;
+        draw(type: "rect"): Rect;
+        draw(type: "line"): Line;
+        draw(type: "polygon"): Polygon;
+        draw(type: "polyline"): Polyline;
+        draw(type: "path"): Path;
+        draw(type: string): Drawable<SVGElement> {
+            const el = drawable(type as any /*FIXME?*/);
+            this.el.appendChild(el.el);
+            return el;
+        }
+
+        element(type: "text", cb: (newElement: Text) => void): this;
+        element(type: "circle", cb: (newElement: Circle) => void): this;
+        element(type: "rect", cb: (newElement: Rect) => void): this;
+        element(type: "line", cb: (newElement: Line) => void): this;
+        element(type: "polygon", cb: (newElement: Polygon) => void): this;
+        element(type: "polyline", cb: (newElement: Polyline) => void): this;
+        element(type: "path", cb: (newElement: Path) => void): this;
+        element(type: string, cb: (newElement: any) => void): this {
+            cb(this.draw(type as any /*FIXME?*/));
+            return this;
+        }
+
+        group(): Group {
+            const g = new Group();
+            this.el.appendChild(g.el);
+            return g;
+        }
+
+        appendChild<T extends SVGElement>(child: BaseElement<T>): void {
+            this.el.appendChild(child.el);
+        }
+    }
+
+    export class SVG extends DrawContext<SVGSVGElement> {
+        defs: DefsElement;
+        constructor(parent?: Element) {
+            super("svg");
+            if (parent) {
+                parent.appendChild(this.el);
+            }
+        }
+
+        define(cb: (defs: DefsElement) => void): this {
+            if (!this.defs) {
+                this.defs = new DefsElement(this.el);
+            }
+            cb(this.defs);
+            return this;
+        }
+    }
+
+    export class Group extends DrawContext<SVGGElement> {
+        top: number;
+        left: number;
+        scaleFactor: number;
+
+        constructor(parent?: SVGElement) {
+            super("g");
+            if (parent) {
+                parent.appendChild(this.el);
+            }
+        }
+
+        translate(x: number, y: number): this {
+            this.left = x;
+            this.top = y;
+            return this.updateTransform();
+        }
+
+        scale(factor: number): this {
+            this.scaleFactor = factor;
+            return this.updateTransform();
+        }
+
+        private updateTransform(): this {
+            let transform = "";
+            if (this.left != undefined) {
+                transform += `translate(${this.left} ${this.top})`
+            }
+            if (this.scaleFactor != undefined) {
+                transform += ` scale(${this.scaleFactor})`
+            }
+            this.setAttribute("transform", transform);
+            return this;
+        }
+    }
+
+    export class Pattern extends DrawContext<SVGPatternElement> {
+        constructor() {
+            super("pattern");
+        }
+
+        units(kind: PatternUnits): this {
+            return this.setAttribute("patternUnits", kind === PatternUnits.objectBoundingBox ? "objectBoundingBox" : "userSpaceOnUse")
+        }
+
+        contentUnits(kind: PatternUnits): this {
+            return this.setAttribute("patternContentUnits", kind === PatternUnits.objectBoundingBox ? "objectBoundingBox" : "userSpaceOnUse")
+        }
+
+        size(width: number, height: number): this {
+            this.setAttribute("width", width);
+            this.setAttribute("height", height);
+            return this;
+        }
+    }
+
+    export class DefsElement extends BaseElement<SVGDefsElement> {
+        constructor(parent: SVGSVGElement) {
+            super("defs");
+            parent.appendChild(this.el);
+        }
+
+        create(type: "path", id: string): Path;
+        create(type: "pattern", id: string): Pattern;
+        create(type: "radialGradient", id: string): RadialGradient;
+        create(type: "linearGradient", id: string): LinearGradient;
+        create(type: string, id: string): BaseElement<any> {
+            let el: BaseElement<SVGElement>;
+            switch (type) {
+                case "path": el = new Path(); break;
+                case "pattern": el = new Pattern(); break;
+                case "radialGradient": el = new RadialGradient(); break;
+                case "linearGradient": el = new LinearGradient(); break;
+                default: el = new BaseElement(type);
+            }
+            el.id(id);
+            this.el.appendChild(el.el);
+            return el;
+        }
+    }
+
+    export class Drawable<T extends SVGElement> extends BaseElement<T> {
+        protected downHandler: PointerHandler;
+        protected upHandler: PointerHandler;
+        protected clickHandler: PointerHandler;
+        private eventsReady = false;
+
+        at(x: number, y: number): this {
+            this.setAttribute("x", x);
+            this.setAttribute("y", y);
+            return this;
+        }
+
+        moveTo(x: number, y: number): this {
+            return this.at(x, y);
+        }
+
+        fill(color: string, opacity?: number): this {
+            this.setAttribute("fill", color);
+            if (opacity != undefined) {
+                this.opacity(opacity);
+            }
+            return this;
+        }
+
+        opacity(opacity: number): this {
+            return this.setAttribute("fill-opacity", opacity);
+        }
+
+        stroke(color: string, width?: number): this {
+            this.setAttribute("stroke", color);
+            if (width != undefined) {
+                this.strokeWidth(width);
+            }
+            return this;
+        }
+
+        strokeWidth(width: number): this {
+            return this.setAttribute("stroke-width", width);
+        }
+
+        strokeOpacity(opacity: number): this {
+            return this.setAttribute("stroke-opacity", opacity);
+        }
+
+        onDown(handler: PointerHandler): this {
+            events.down(this.el, handler);
+            return this;
+        }
+
+        onUp(handler: PointerHandler): this {
+            events.up(this.el, handler);
+            return this;
+        }
+
+        onMove(handler: PointerHandler): this {
+            events.move(this.el, handler);
+            return this;
+        }
+
+        onEnter(handler: (isDown: boolean) => void): this {
+            events.enter(this.el, handler);
+            return this;
+        }
+
+        onLeave(handler: PointerHandler): this {
+            events.leave(this.el, handler);
+            return this;
+        }
+    }
+
+    export class Text extends Drawable<SVGTextElement> {
+        constructor(text?: string) {
+            super("text");
+
+            if (text != undefined) {
+                this.text(text);
+            }
+        }
+
+        text(text: string): this {
+            this.el.textContent = text;
+            return this;
+        }
+
+        alignmentBaseline(type: string) {
+            return this.setAttribute("alignment-baseline", type);
+        }
+
+        anchor(type: "start" | "middle" | "end" | "inherit") {
+            return this.setAttribute("text-anchor", type);
+        }
+    }
+
+    export class Rect extends Drawable<SVGRectElement> {
+        constructor() { super("rect") };
+
+        width(width: number): this {
+            return this.setAttribute("width", width);
+        }
+
+        height(height: number): this {
+            return this.setAttribute("height", height);
+        }
+
+        corner(radius: number): this {
+            return this.corners(radius, radius);
+        }
+
+        corners(rx: number, ry: number): this {
+            this.setAttribute("rx", rx);
+            this.setAttribute("ry", ry);
+            return this;
+        }
+
+        size(width: number, height: number): this {
+            this.width(width);
+            this.height(height);
+            return this;
+        }
+    }
+
+    export class Circle extends Drawable<SVGCircleElement> {
+        constructor() { super("circle"); }
+
+        at(cx: number, cy: number): this {
+            this.setAttribute("cx", cx);
+            this.setAttribute("cy", cy);
+            return this;
+        }
+
+        radius(r: number): this {
+            return this.setAttribute("r", r);
+        }
+    }
+
+    class Ellipse extends Drawable<SVGEllipseElement> {
+        constructor() { super("ellipse"); }
+
+        at(cx: number, cy: number): this {
+            this.setAttribute("cx", cx);
+            this.setAttribute("cy", cy);
+            return this;
+        }
+
+        radius(rx: number, ry: number): this {
+            this.setAttribute("rx", rx);
+            this.setAttribute("ry", ry);
+            return this;
+        }
+    }
+
+    export class Line extends Drawable<SVGLineElement> {
+        constructor() { super("line"); }
+
+        at(x1: number, y1: number, x2?: number, y2?: number): this {
+            this.from(x1, y1);
+            if (x2 != undefined && y2 != undefined) {
+                this.to(x2, y2);
+            }
+            return this;
+        }
+
+        from(x1: number, y1: number): this {
+            this.setAttribute("x1", x1);
+            this.setAttribute("y1", y1);
+            return this;
+        }
+
+        to(x2: number, y2: number): this {
+            this.setAttribute("x2", x2);
+            this.setAttribute("y2", y2);
+            return this;
+        }
+    }
+
+    export class PolyElement<T extends SVGPolygonElement | SVGPolylineElement> extends Drawable<T> {
+        points(points: string): this {
+            return this.setAttribute("points", points);
+        }
+
+        with(points: {
+            x: number;
+            y: number;
+        }[]): this {
+            return this.points(points.map(({ x, y }) => x + " " + y).join(","))
+        }
+    }
+
+    export class Polyline extends PolyElement<SVGPolylineElement> {
+        constructor() { super("polyline") }
+    }
+
+    export class Polygon extends PolyElement<SVGPolygonElement> {
+        constructor() { super("polygon") }
+    }
+
+    export class Path extends Drawable<SVGPathElement> {
+        d: PathContext;
+        
+        constructor() {
+            super("path");
+            this.d = new PathContext();
+        }
+
+        update(): this {
+            return this.setAttribute("d", this.d.toAttribute());
+        }
+
+        draw(cb: (d: PathContext) => void): this {
+            cb(this.d);
+            return this.update();
+        }
+    }
+
+    export class Gradient<T extends SVGGradientElement> extends BaseElement<T> {
+        units(kind: PatternUnits): this {
+            return this.setAttribute("gradientUnits", kind === PatternUnits.objectBoundingBox ? "objectBoundingBox" : "userSpaceOnUse")
+        }
+
+        stop(offset: number, color?: string, opacity?: string): this {
+            const s = elt("stop");
+            s.setAttribute("offset", offset + "%");
+            if (color != undefined) {
+                s.setAttribute("stop-color", color);
+            }
+
+            if (opacity != undefined) {
+                s.setAttribute("stop-opacity", opacity);
+            }
+
+            this.el.appendChild(s);
+            return this;
+        }
+    }
+
+    export class LinearGradient extends Gradient<SVGLinearGradientElement> {
+        constructor() { super("linearGradient"); }
+
+        start(x1: number, y1: number): this {
+            this.setAttribute("x1", x1);
+            this.setAttribute("y1", y1);
+            return this;
+        }
+
+        end(x2: number, y2: number): this {
+            this.setAttribute("x2", x2);
+            this.setAttribute("y2", y2);
+            return this;
+        }
+    }
+    
+    export class RadialGradient extends Gradient<SVGRadialGradientElement> {
+        constructor() { super("radialGradient"); }
+
+        center(cx: number, cy: number): this {
+            this.setAttribute("cx", cx);
+            this.setAttribute("cy", cy);
+            return this;
+        }
+
+        focus(fx: number, fy: number, fr: number): this {
+            this.setAttribute("fx", fx);
+            this.setAttribute("fy", fy);
+            this.setAttribute("fr", fr);
+            return this;
+        }
+
+        radius(r: number): this {
+            return this.setAttribute("r", r);
+        }
+    }
+
+    function elt(type: string): SVGElement {
+        let el = document.createElementNS("http://www.w3.org/2000/svg", type);
+        return el;
+    }
+
+    function drawable(type: "text"): Text;
+    function drawable(type: "circle"): Circle;
+    function drawable(type: "rect"): Rect;
+    function drawable(type: "line"): Line;
+    function drawable(type: "polygon"): Polygon;
+    function drawable(type: "polyline"): Polyline;
+    function drawable(type: "path"): Path;
+    function drawable(type: string): Drawable<SVGElement> {
+        switch (type) {
+            case "text": return new Text();
+            case "circle": return new Circle();
+            case "rect": return new Rect();
+            case "line": return new Line();
+            case "polygon": return new Polygon();
+            case "polyline": return new Polyline();
+            case "path": return new Path();
+            default: return new Drawable(type);
+        }
+    }
+
+    export type OperatorSymbol = "m" | "M" | "l" | "L" | "c" | "C" | "q" | "Q" | "T" | "t" | "S" | "s" | "z" | "Z" | "A";
+    export interface PathOp {
+        op: OperatorSymbol;
+        args: number[];
+    }
+    export class PathContext {
+        private ops: PathOp[] = [];
+
+        clear(): void {
+            this.ops = [];
+        }
+
+        moveTo(x: number, y: number): this {
+            return this.op("M", x, y);
+        }
+
+        moveBy(dx: number, dy: number): this {
+            return this.op("m", dx, dy);
+        }
+
+        lineTo(x: number, y: number): this {
+            return this.op("L", x, y);
+        }
+
+        lineBy(dx: number, dy: number): this {
+            return this.op("l", dx, dy);
+        }
+
+        cCurveTo(c1x: number, c1y: number, c2x: number, c2y: number, x: number, y: number): this {
+            return this.op("C", c1x, c1y, c2x, c2y, x, y);
+        }
+
+        cCurveBy(dc1x: number, dc1y: number, dc2x: number, dc2y: number, dx: number, dy: number): this {
+            return this.op("c", dc1x, dc1y, dc2x, dc2y, dx, dy);
+        }
+
+        qCurveTo(cx: number, cy: number, x: number, y: number): this {
+            return this.op("Q", cx, cy, x, y);
+        }
+
+        qCurveBy(dcx: number, dcy: number, dx: number, dy: number): this {
+            return this.op("q", dcx, dcy, dx, dy);
+        }
+
+        sCurveTo(cx: number, cy: number, x: number, y: number): this {
+            return this.op("S", cx, cy, x, y);
+        }
+
+        sCurveBy(dcx: number, dcy: number, dx: number, dy: number): this {
+            return this.op("s", dcx, dcy, dx, dy);
+        }
+
+        tCurveTo(x: number, y: number): this {
+            return this.op("T", x, y);
+        }
+
+        tCurveBy(dx: number, dy: number): this {
+            return this.op("t", dx, dy);
+        }
+
+        arcTo(rx: number, ry: number, xRotate: number, large: boolean, sweepClockwise: boolean, x: number, y: number): this {
+            return this.op("A", rx, ry, xRotate, large ? 1 : 0, sweepClockwise ? 1 : 0, x, y);
+        }
+
+        close(): this {
+            return this.op("z");
+        }
+
+        toAttribute(): string {
+            return this.ops.map(op => op.op + " " + op.args.join(" ")).join(" ");
+        }
+
+        private op(op: OperatorSymbol, ...args: number[]) {
+            this.ops.push({
+                op,
+                args
+            });
+            return this;
+        }
+    }
+}
+
+namespace svgUtil.events {
+    export function isTouchEnabled(): boolean {
+        return typeof window !== "undefined" &&
+            ('ontouchstart' in window                              // works on most browsers
+                || (navigator && navigator.maxTouchPoints > 0));       // works on IE10/11 and Surface);
+    }
+
+    export function hasPointerEvents(): boolean {
+        return typeof window != "undefined" && !!(window as any).PointerEvent;
+    }
+
+    export function down(el: SVGElement, handler: () => void) {
+        if (hasPointerEvents()) {
+            el.addEventListener("pointerdown", handler);
+        }
+        else if (isTouchEnabled()) {
+            el.addEventListener("mousedown", handler);
+            el.addEventListener("touchstart", handler);
+        }
+        else {
+            el.addEventListener("mousedown", handler);
+        }
+    }
+
+    export function up(el: SVGElement, handler: () => void) {
+        if (hasPointerEvents()) {
+            el.addEventListener("pointerup", handler);
+        }
+        else if (isTouchEnabled()) {
+            el.addEventListener("mouseup", handler);
+        }
+        else {
+            el.addEventListener("mouseup", handler);
+        }
+    }
+
+    export function enter(el: SVGElement, handler: (isDown: boolean) => void) {
+        if (hasPointerEvents()) {
+            el.addEventListener("pointerover", e => {
+                handler(!!(e.buttons & 1))
+            });
+        }
+        else if (isTouchEnabled()) {
+            el.addEventListener("touchstart", e => {
+                handler(true);
+            });
+        }
+        else {
+            el.addEventListener("mouseover", e => {
+                handler(!!(e.buttons & 1))
+            });
+        }
+    }
+
+    export function leave(el: SVGElement, handler: () => void) {
+        if (hasPointerEvents()) {
+            el.addEventListener("pointerleave", handler);
+        }
+        else if (isTouchEnabled()) {
+            el.addEventListener("touchend", handler);
+        }
+        else {
+            el.addEventListener("mouseleave", handler);
+        }
+    }
+
+    export function move(el: SVGElement, handler: () => void) {
+        if (hasPointerEvents()) {
+            el.addEventListener("pointermove", handler);
+        }
+        else if (isTouchEnabled()) {
+            el.addEventListener("touchmove", handler);
+        }
+        else {
+            el.addEventListener("mousemove", handler);
+        }
+    }
+}
+
+namespace svgUtil.helpers {
+    export class CenteredText extends Text {
+        protected cx: number;
+        protected cy: number;
+
+        protected fontSizePixels: number;
+
+        public at(cx: number, cy: number): this {
+            this.cx = cx;
+            this.cy = cy;
+            this.rePosition();
+
+            return this;
+        }
+
+        public text(text: string, fontSizePixels = 12) {
+            super.text(text);
+            this.fontSizePixels = fontSizePixels;
+            this.setAttribute("font-size", fontSizePixels + "px");
+
+            this.rePosition();
+
+            return this;
+        }
+
+        protected rePosition() {
+            if (this.cx == undefined || this.cy == undefined || this.fontSizePixels == undefined) {
+                return;
+            }
+
+            this.setAttribute("x", this.cx);
+            this.setAttribute("y", this.cy);
+            this.setAttribute("text-anchor", "middle");
+            this.setAttribute("alignment-baseline", "middle");
+        }
+    }
+}


### PR DESCRIPTION
Add support for a control pad UI and makes the sim full screen.

The `svg.ts` business is a little SVG rendering library I wrote while working on the sprite editor and getting frustrated with what we have in pxsim. I'll move it to PXT eventually, but I'm putting it here for now so that I can iterate on it faster.