### PR TITLE
Remove forever for frame

### DIFF
--- a/docs/docs.md
+++ b/docs/docs.md
@@ -1,14 +1,3 @@
-# Docs for Sample Target
+# Docs
 
-This is a pure javascript sample target for [Microsoft MakeCode](https://makecode.com). 
-For more information about setting your own target, 
-see https://makecode.com/packages .
-
-You can embed code snippets and [more](https://makecode.com/markdown)
-
-```blocks
-loops.forever(() => {
-    turtle.turn(Direction.Left, 10);
-    turtle.forward(1);
-});
-```
+TODO

--- a/docs/examples/asteroids.md
+++ b/docs/examples/asteroids.md
@@ -37,7 +37,7 @@ spaceship.onCollision(function (other: Sprite) {
 })
 spaceship.z = 10
 
-loops.frame(function () {
+frame(function () {
     spaceship.x += keys.dx(70)
     spaceship.x = Math.clamp(10, 118, spaceship.x)
 

--- a/docs/examples/car-race.md
+++ b/docs/examples/car-race.md
@@ -61,7 +61,7 @@ let pos = 0
 let prevPos = 0
 
 
-loops.frame(function () {
+frame(function () {
     pos += 1 + Math.sqrt(control.millis()) / 200.0
     drive(pos - prevPos)
     prevPos = pos | 0

--- a/docs/examples/duck.md
+++ b/docs/examples/duck.md
@@ -79,7 +79,7 @@ keys.A.onPressed(function () {
 })
 
 game.setBackground(4)
-loops.frame(function () {
+frame(function () {
     if (Math.random() < 0.02) {
         let s = sprites.launchParticle(cloudImg, -45, 0)
         s.y = Math.randomRange(0, screen.height())

--- a/docs/examples/jumper.md
+++ b/docs/examples/jumper.md
@@ -69,7 +69,7 @@ player.onCollision(function (other: Sprite) {
 
 
 let frameCount = 0;
-loops.frame(function () {
+frame(function () {
     // Periodically spawn an obstacle and increase the difficulty.
     // This math assumes the game is running at 60 FPS
     frameCount = (frameCount + 1) % Math.floor(60 / obstaclesPerSecond)

--- a/docs/examples/mega-bounce.md
+++ b/docs/examples/mega-bounce.md
@@ -32,7 +32,7 @@ let counter = 0
 
 addBall(80);
 
-loops.frame(function () {
+frame(function () {
     counter++;
     for (const ball of balls) {
         if (ball.collidesWith(paddle)) {

--- a/docs/examples/runner.md
+++ b/docs/examples/runner.md
@@ -68,7 +68,7 @@ jumper.onCollision(function (h: Sprite) {
     }
 })
 
-loops.frame(function () {
+frame(function () {
     if (keys.A.isPressed() && jumper.vy >= 0)
         jumper.vy = -100
 

--- a/docs/examples/snake.md
+++ b/docs/examples/snake.md
@@ -75,7 +75,7 @@ function show() {
 
 newFood()
 
-loops.frame(function () {
+frame(function () {
     if (keys.dx()) {
         dx = Math.sign(keys.dx())
         dy = 0

--- a/libs/blocksprj/main.blocks
+++ b/libs/blocksprj/main.blocks
@@ -1,5 +1,5 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
   <variables></variables>
   <block type="pxt-on-start" x="0" y="0"></block>
-  <block type="device_forever" x="180" y="0"></block>
+  <block type="frame" x="180" y="0"></block>
 </xml>

--- a/libs/blocksprj/main.blocks
+++ b/libs/blocksprj/main.blocks
@@ -1,2 +1,5 @@
 <xml xmlns="http://www.w3.org/1999/xhtml">
+  <variables></variables>
+  <block type="pxt-on-start" x="0" y="0"></block>
+  <block type="device_forever" x="180" y="0"></block>
 </xml>

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -154,22 +154,6 @@ function pauseUntil(condition: () => boolean, timeOut?: number): void {
     control.__queuePollEvent(timeOut, condition, undefined);
 }
 
-
-let __foreverCb: () => void = undefined;
-/**
- * Repeats the code forever in the background. On each iteration, allows other codes to run.
- * @param body code to execute
- */
-//% help=loops/forever weight=100 afterOnStart=true blockNamespace="loops"
-//% blockId=forever block="forever"
-function forever(a: () => void): void {
-    if (!__foreverCb)
-        control.addFrameHandler(20, function() {
-            if (__foreverCb) __foreverCb();
-        });
-    __foreverCb = a;
-}
-
 /**
  * Pause for the specified time in milliseconds
  * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -154,14 +154,20 @@ function pauseUntil(condition: () => boolean, timeOut?: number): void {
     control.__queuePollEvent(timeOut, condition, undefined);
 }
 
+
+let __foreverCb: () => void = undefined;
 /**
  * Repeats the code forever in the background. On each iteration, allows other codes to run.
  * @param body code to execute
  */
 //% help=loops/forever weight=100 afterOnStart=true blockNamespace="loops"
-//% blockId=forever block="forever" blockAllowMultiple=1
+//% blockId=forever block="forever"
 function forever(a: () => void): void {
-    loops.forever(a);
+    if (!__foreverCb)
+        control.addFrameHandler(20, function() {
+            if (__foreverCb) __foreverCb();
+        });
+    __foreverCb = a;
 }
 
 /**
@@ -171,6 +177,6 @@ function forever(a: () => void): void {
 //% help=loops/pause weight=99
 //% async block="pause %pause=timePicker|ms"
 //% blockId=device_pause blockNamespace="loops"
+//% shims=loops::pause
 function pause(ms: number): void {
-    loops.pause(ms);
 }

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -161,6 +161,6 @@ function pauseUntil(condition: () => boolean, timeOut?: number): void {
 //% help=loops/pause weight=99
 //% async block="pause %pause=timePicker|ms"
 //% blockId=device_pause blockNamespace="loops"
-//% shims=loops::pause
+//% shim=pauseAsync promise
 function pause(ms: number): void {
 }

--- a/libs/core/sims.d.ts
+++ b/libs/core/sims.d.ts
@@ -1,24 +1,4 @@
 // Auto-generated from simulator. Do not edit.
-declare namespace loops {
-    /**
-     * Repeats the code forever in the background. On each iteration, allows other code to run.
-     * @param body the code to repeat
-     */
-    //% help=functions/forever weight=55 blockGap=8
-    //% blockId=device_forever block="forever"
-    //% shim=loops::forever
-    function forever(body: () => void): void;
-
-    /**
-     * Pause for the specified time in milliseconds
-     * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
-     */
-    //% help=functions/pause weight=54
-    //% block="pause (ms) %pause" blockId=device_pause_loops
-    //% shim=loops::pauseAsync promise
-    function pause(ms: number): void;
-
-}
 declare namespace console {
     /**
      * Print out message

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -23,7 +23,7 @@ namespace game {
 
     export function freeze() {
         setBackgroundCallback(() => { })
-        forever(() => { })
+        frame(() => { })
         sprites.allSprites = [];
     }
 

--- a/libs/game/game.ts
+++ b/libs/game/game.ts
@@ -18,12 +18,12 @@ namespace game {
 
     export function waitAnyKey() {
         if (_waitAnyKey) _waitAnyKey()
-        else loops.pause(2000)
+        else pause(2000)
     }
 
     export function freeze() {
         setBackgroundCallback(() => { })
-        loops.frame(() => { })
+        forever(() => { })
         sprites.allSprites = [];
     }
 
@@ -120,7 +120,7 @@ namespace game {
                 screen.set(x, y + 1, c)
                 screen.set(x, y + 2, c)
             }
-            loops.pause(100)
+            pause(100)
         }
     }
 
@@ -141,7 +141,7 @@ namespace game {
             screen.printCenter("GAME OVER!", top + 8, 5, image.font8)
             if (hud.hasScore())
                 screen.printCenter("Score:" + hud.score(), top + 23, 2, image.font5)
-            loops.pause(1000) // wait for users to stop pressing keys
+            pause(1000) // wait for users to stop pressing keys
             waitAnyKey()
             control.reset()
         })

--- a/libs/game/sprites.ts
+++ b/libs/game/sprites.ts
@@ -1,7 +1,7 @@
 /*
 Frame handlers:
  10 - physics and collisions
- 20 - loops.frame()
+ 20 - frame()
  60 - screen/sprite background
  90 - drawing sprites
  95 - drawing score

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "typescript": "2.6.1"
   },
   "dependencies": {
-    "pxt-common-packages": "0.20.6",
+    "pxt-common-packages": "0.20.7",
     "pxt-core": "3.5.2"
   }
 }

--- a/sim/api.ts
+++ b/sim/api.ts
@@ -40,23 +40,7 @@ namespace pxsim {
     }
 }
 
-namespace pxsim.loops {
-    /**
-     * Repeats the code forever in the background. On each iteration, allows other code to run.
-     * @param body the code to repeat
-     */
-    //% help=functions/forever weight=55 blockGap=8
-    //% blockId=device_forever block="forever" 
-    export function forever(body: RefAction): void {
-        thread.forever(body)
-    }
-
-    /**
-     * Pause for the specified time in milliseconds
-     * @param ms how long to pause for, eg: 100, 200, 500, 1000, 2000
-     */
-    //% help=functions/pause weight=54
-    //% block="pause (ms) %pause" blockId=device_pause_loops
+namespace pxsim {
     export function pauseAsync(ms: number) {
         return Promise.delay(ms)
     }


### PR DESCRIPTION
To stay compatible with the other targets, we only support "frame" in pxt-32 (better name maybe). Forever is not available so that it does not bring confusion and code produced here would still be compatible in common packages.

![image](https://user-images.githubusercontent.com/4175913/37320204-d46a6f80-262f-11e8-887c-2fa9a32a143a.png)
