### PR TITLE
Use number instead of strings for events

### DIFF
--- a/libs/core/buffer.d.ts
+++ b/libs/core/buffer.d.ts
@@ -98,5 +98,5 @@ declare namespace control {
      */
     //% help=control/wait-for-event async
     //% blockId=control_wait_for_event block="wait for event|from %src|with value %value" shim=control::waitForEvent
-    function waitForEvent(src: string, value: int32): void;
+    function waitForEvent(src: number, value: int32): void;
 }

--- a/libs/core/control.ts
+++ b/libs/core/control.ts
@@ -3,16 +3,16 @@
 */
 //% weight=10 color="#31bca3" icon="\uf110" advanced=true
 namespace control {
-    const DEVICE_ID_NOTIFY = "notify";
-    const DEVICE_ID_NOTIFY_ONE = "notifyone";
-
+    // https://github.com/lancaster-university/codal-core/blob/c1280524f508c6150f51b77c130eb467976b4cf6/inc/core/CodalComponent.h#L60
+    const DEVICE_ID_NOTIFY_ONE = 1022;
+    const DEVICE_ID_NOTIFY = 1023;
     let nextNotifyEvent = 1;
 
     export function allocateNotifyEvent(): number {
         return nextNotifyEvent++;
     }
-    export function allocatePollEvent(): string {
-        return "poll" + nextNotifyEvent++;
+    export function allocatePollEvent(): number {
+        return nextNotifyEvent++;
     }
     
     export class AnimationQueue {
@@ -77,13 +77,13 @@ namespace control {
     }
 
     class PollEvent {
-        public eid: string;
+        public eid: number;
         public vid: number;
         public start: number;
         public timeOut: number;
         public condition: () => boolean;
         public once: boolean;
-        constructor(eid: string, vid: number, start: number, timeOut: number, condition: () => boolean, once: boolean) {
+        constructor(eid: number, vid: number, start: number, timeOut: number, condition: () => boolean, once: boolean) {
             this.eid = eid;
             this.vid = vid;
             this.start = start;

--- a/libs/core/sims.d.ts
+++ b/libs/core/sims.d.ts
@@ -14,14 +14,14 @@ declare namespace control {
      */
     //%
     //% shim=control::onEvent
-    function onEvent(ev: string, arg: number, f: () => void): void;
+    function onEvent(ev: number, arg: number, f: () => void): void;
 
     /**
      * Generate an event
      */
     //%
     //% shim=control::raiseEvent
-    function raiseEvent(ev: string, arg: number): void;
+    function raiseEvent(ev: number, arg: number): void;
 
     /**
      * Create a new zero-initialized buffer.

--- a/libs/keys/enums.ts
+++ b/libs/keys/enums.ts
@@ -1,0 +1,4 @@
+const KEY_UP = 2048;
+const KEY_DOWN = 2049;
+const INTERNAL_KEY_UP = 2050;
+const INTERNAL_KEY_DOWN = 2051;

--- a/libs/keys/keys.ts
+++ b/libs/keys/keys.ts
@@ -1,8 +1,8 @@
 enum KeyEvent {
     //% block="pressed"
-    Pressed,
+    Pressed = KEY_DOWN,
     //% block="released"
-    Released
+    Released = KEY_UP
 }
 
 /**
@@ -10,11 +10,6 @@ enum KeyEvent {
  */
 //% weight=97 color="#5B0F4D" icon="\uf11b"
 namespace keys {
-    const eventNames = [
-        "keydown",
-        "keyup"
-    ];
-
     //% fixedInstances
     export class Key {
         id: number
@@ -25,18 +20,19 @@ namespace keys {
             this.id = id
             this._pressed = false
             this.checked = false
-            control.onEvent("_keyup", id, () => {
+            control.onEvent(INTERNAL_KEY_UP, id, () => {
                 if (this._pressed) {
                     this._pressed = false
-                    control.raiseEvent("keyup", id)
+                    control.raiseEvent(KEY_UP, id)
+                    control.raiseEvent(KEY_UP, 0)
                 }
             })
-            control.onEvent("_keydown", id, () => {
+            control.onEvent(INTERNAL_KEY_DOWN, id, () => {
                 if (!this._pressed) {
                     this._pressed = true
                     this.checked = false
-                    control.raiseEvent("keydown", id)
-                    control.raiseEvent("keydown", 0)
+                    control.raiseEvent(KEY_DOWN, id)
+                    control.raiseEvent(KEY_DOWN, 0)
                 }
             })
         }
@@ -47,7 +43,7 @@ namespace keys {
         //% weight=99 blockGap=8
         //% blockId=keyonevent block="on %key **key** %event"
         onEvent(event: KeyEvent, handler: () => void) {
-            control.onEvent(eventNames[event], this.id, handler);
+            control.onEvent(event, this.id, handler);
         }
 
         /**
@@ -56,8 +52,8 @@ namespace keys {
         //% weight=98 blockGap=8
         //% blockId=keypauseuntil block="pause until %key **key** is %event"
         pauseUntil(event: KeyEvent) {
-            control.waitForEvent(eventNames[event], this.id)
-        }        
+            control.waitForEvent(event, this.id)
+        }
 
         /** 
          * Indicates if the key is currently pressed
@@ -119,6 +115,6 @@ namespace keys {
     //% weight=10
     //% blockId=keypauseuntilanykey block="pause until any key"
     export function pauseUntilAnyKey() {
-        control.waitForEvent("keydown", 0)
+        control.waitForEvent(KEY_DOWN, 0)
     }
 }

--- a/libs/keys/keys.ts
+++ b/libs/keys/keys.ts
@@ -92,10 +92,10 @@ namespace keys {
     //% weight=50 blockGap=8
     //% blockId=keysdx block="dx %step"
     export function dx(step: number) {
-        if (keys.Left.isPressed())
-            if (keys.Right.isPressed()) return 0
+        if (keys.left.isPressed())
+            if (keys.right.isPressed()) return 0
             else return -step * control.deltaTime
-        else if (keys.Right.isPressed()) return step * control.deltaTime
+        else if (keys.right.isPressed()) return step * control.deltaTime
         else return 0
     }
 
@@ -106,10 +106,10 @@ namespace keys {
     //% weight=49
     //% blockId=keysdy block="dy %step"
     export function dy(step: number) {
-        if (keys.Up.isPressed())
-            if (keys.Down.isPressed()) return 0
+        if (keys.up.isPressed())
+            if (keys.down.isPressed()) return 0
             else return -step * control.deltaTime
-        else if (keys.Down.isPressed()) return step * control.deltaTime
+        else if (keys.down.isPressed()) return step * control.deltaTime
         else return 0
     }
 

--- a/libs/keys/pxt.json
+++ b/libs/keys/pxt.json
@@ -2,6 +2,7 @@
     "name": "keys",
     "description": "Handling keys",
     "files": [
+        "enums.ts",
         "keys.ts",
         "targetoverrides.ts"
     ],

--- a/libs/keys/targetoverrides.ts
+++ b/libs/keys/targetoverrides.ts
@@ -1,12 +1,12 @@
 namespace keys {
     //% fixedInstance block="left"
-    export const Left = new Key(1)
+    export const left = new Key(1)
     //% fixedInstance block="up"
-    export const Up = new Key(2)
+    export const up = new Key(2)
     //% fixedInstance block="right"
-    export const Right = new Key(3)
+    export const right = new Key(3)
     //% fixedInstance block="down"
-    export const Down = new Key(4)
+    export const down = new Key(4)
     //% fixedInstance block="A"
     export const A = new Key(5)
     //% fixedInstance block="B"

--- a/sim/api.ts
+++ b/sim/api.ts
@@ -65,7 +65,7 @@ namespace pxsim.control {
      * Listen to a event
      */
     //% 
-    export function onEvent(ev: string, arg: number, f: RefAction) {
+    export function onEvent(ev: number, arg: number, f: RefAction) {
         board().bus.listen(ev, arg, f)
     }
 
@@ -73,7 +73,7 @@ namespace pxsim.control {
      * Generate an event
      */
     //% 
-    export function raiseEvent(ev: string, arg: number) {
+    export function raiseEvent(ev: number, arg: number) {
         board().bus.queue(ev, arg)
     }
 
@@ -109,7 +109,7 @@ namespace pxsim.control {
 
     export let runInParallel = thread.runInBackground;
 
-    export function waitForEvent(id: string, evid: number) {
+    export function waitForEvent(id: number, evid: number) {
         const cb = getResume();
         board().bus.wait(id, evid, cb);
     }

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -1,4 +1,5 @@
 /// <reference path="../node_modules/pxt-core/built/pxtsim.d.ts"/>
+/// <reference path="../libs/keys/enums.ts"/>
 
 namespace pxsim {
     export type CommonBoard = Board
@@ -123,7 +124,7 @@ namespace pxsim {
         getDefaultPitchPin(): Pin {
             return undefined;
         }
-        
+
         setKey(which: number, isPressed: boolean) {
             let k = mapKey(which)
             if (k) {
@@ -133,7 +134,7 @@ namespace pxsim {
 
         handleKeyEvent(key: Key, isPressed: boolean) {
             this.lastKey = Date.now()
-            this.bus.queue(isPressed ? "_keydown" : "_keyup", key)
+            this.bus.queue(isPressed ? INTERNAL_KEY_DOWN : INTERNAL_KEY_UP, key)
             if (this.controls) {
                 this.controls.mirrorKey(key, isPressed);
             }


### PR DESCRIPTION
C++ uses numbers so it's easier to use this datatype to declare events.