### PR TITLE
Blur controls when not in focus (+ resizing fixes)

### DIFF
--- a/sim/controlPad.ts
+++ b/sim/controlPad.ts
@@ -5,7 +5,7 @@ namespace pxsim {
 
     const COMPONENT_WIDTH = 60;
     const DRAW_UNIT = COMPONENT_WIDTH / 3;
-    const PADDING = 30;
+    const PADDING = 20;
 
     const D_PAD_COLOR = "#6B4F76";
     const D_PAD_DOWN_COLOR = "#f4b342";

--- a/sim/public/sim.css
+++ b/sim/public/sim.css
@@ -1,8 +1,12 @@
+html, body {
+    margin: 0 !important;
+    height: 100%;
+}
+
 body {
     font-size: 12px;
     color: white;
-    height: 100vh;
-    font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace
+    font-family: Monaco, Menlo, "Ubuntu Mono", Consolas, source-code-pro, monospace;
 }
 
 .sprite {
@@ -22,7 +26,7 @@ canvas {
 
 #screen-back {
     background: #FFFAE7;
-    height: 94%;
+    height: calc(100% - 10px);
     position: absolute;
     z-index: -1;
     margin-left: auto;
@@ -39,8 +43,7 @@ canvas {
     align-content: center;
     justify-content: center;
     align-items: center;
-    height: 100%;
-    padding-top: 10px;
+    height: 100vh;
 }
 
 .has-focus {
@@ -50,7 +53,7 @@ canvas {
 #paint-surface {
     object-fit: contain;
     display: inline;
-    height: 100%;
+    height: calc(100% - 14px);
     border: 7px solid #6B4F76;
     border-radius: 5px;
     border-left-width: 12px;
@@ -58,9 +61,11 @@ canvas {
 }
 
 #paint-surface-container {
+    padding-top: 10px;
     width: 100%;
     flex: 5;
     text-align: center;
+    overflow-y: hidden;
 }
 
 #debug-stats {
@@ -72,7 +77,15 @@ canvas {
 
 #controls {
     flex: 1;
-    padding-bottom: 25px;
+    width: 100%;
+    text-align: center;
+}
+
+#controls.no-focus {
+    opacity: 0.5;
+    -moz-filter: blur(3px);
+    -webkit-filter: blur(3px);
+    filter: blur(3px);
 }
 
 .stats {

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -251,7 +251,7 @@ namespace pxsim {
             }
 
             let info = document.getElementById("instructions")
-            indicateFocus(false);
+            indicateFocus(document.hasFocus());
 
             return Promise.resolve();
         }

--- a/sim/simulator.ts
+++ b/sim/simulator.ts
@@ -104,6 +104,7 @@ namespace pxsim {
         public bus: EventBus;
         public audioState: AudioState;
         public background: HTMLDivElement;
+        public controlsDiv: HTMLDivElement;
         public canvas: HTMLCanvasElement;
         public stats: HTMLElement;
         public screen: Uint32Array;
@@ -205,9 +206,13 @@ namespace pxsim {
             this.canvas.height = 16;
 
             if (!this.controls) {
-                const controlDiv = document.getElementById("controls");
-                controlDiv.innerHTML = "";
-                this.controls = new ControlPad(controlDiv);
+                this.controlsDiv = document.getElementById("controls") as HTMLDivElement;
+                this.controlsDiv.innerHTML = "";
+                this.controls = new ControlPad(this.controlsDiv);
+
+                this.controlsDiv.onmouseover = () => {
+                    if (!document.hasFocus()) window.focus();
+                }
             }
 
             let requested = false
@@ -246,20 +251,24 @@ namespace pxsim {
             }
 
             let info = document.getElementById("instructions")
+            indicateFocus(false);
 
             return Promise.resolve();
         }
     }
 
     function indicateFocus(hasFocus: boolean) {
-        const c = board().background;
-        if (!c) return;
+        const b = board().background;
+        const c = board().controlsDiv;
+        if (!b || !c) return;
 
         if (hasFocus) {
-            c.classList.add("has-focus");
+            b.classList.add("has-focus");
+            c.classList.remove("no-focus");
         }
         else {
-            c.classList.remove("has-focus");
+            b.classList.remove("has-focus");
+            c.classList.add("no-focus");
         }
     }
 }


### PR DESCRIPTION
Fix a bunch of sim resizing issues. 

Blur controls when not in focus.
Focus on mouse over of controls.

![blurcontrols](https://user-images.githubusercontent.com/16690124/37654226-a1acf822-2bfe-11e8-9911-73c3b3b04d69.gif)
