### PR TITLE
More sprite editor improvements

### DIFF
--- a/editor/bitmap.ts
+++ b/editor/bitmap.ts
@@ -92,4 +92,10 @@ namespace mkcd {
             return (this.mask[index] >> offset) & 1;
         }
     }
+
+    export function resizeBitmap(img: Bitmap, width: number, height: number) {
+        const result = new Bitmap(width, height);
+        result.apply(img);
+        return result;
+    }
 }

--- a/editor/bitmapImage.ts
+++ b/editor/bitmapImage.ts
@@ -5,33 +5,41 @@
 
 
 namespace mkcd {
+    import svg = svgUtil;
     export class BitmapImage extends Grid {
-        protected state: Bitmap;
+        public image: Bitmap;
         protected palette: string[];
+        protected overlay: svg.Group;
 
         constructor(props: Partial<GridStyleProps>, img: Bitmap, palette: string[]) {
             super(bitmapImageProps(props, img));
-            
-            this.state = img;
+
+            this.image = img;
             this.palette = palette;
             this.repaint();
         }
 
         repaint() {
-            for (let c = 0; c < this.state.width; c++) {
-                for (let r = 0; r < this.state.height; r++) {
-                    this.setCellColor(c, r, this.palette[this.state.get(c, r)])
+            for (let c = 0; c < this.image.width; c++) {
+                for (let r = 0; r < this.image.height; r++) {
+                    this.setCellColor(c, r, this.palette[this.image.get(c, r)])
                 }
             }
         }
 
         writeColor(col: number, row: number, color: number) {
-            this.state.set(col, row, color);
+            this.image.set(col, row, color);
             this.setCellColor(col, row, this.palette[color]);
         }
 
         restore(bitmap: Bitmap, repaint = false) {
-            this.state.apply(bitmap);
+            if (bitmap.height != this.image.height || bitmap.width != this.image.width) {
+                this.image = bitmap.copy();
+                this.resizeGrid(bitmap.width, bitmap.width * bitmap.height);
+            }
+            else {
+                this.image.apply(bitmap);
+            }
 
             if (repaint) {
                 this.repaint();
@@ -39,12 +47,52 @@ namespace mkcd {
         }
 
         applyEdit(edit: Edit) {
-            edit.doEdit(this.state);
+            edit.doEdit(this.image);
             this.repaint();
         }
 
         bitmap() {
-            return this.state;
+            return this.image;
+        }
+
+        showOverlay() {
+            if (!this.overlay) {
+                this.overlay = new svg.Group;
+                if (this.dragSurface) {
+                    this.group.el.insertBefore(this.overlay.el, this.dragSurface.el);
+                }
+                else {
+                    this.group.appendChild(this.overlay);
+                }
+            }
+            else {
+                this.overlay.el.innerHTML = "";
+            }
+
+            const width = this.outerWidth();
+            const height = this.outerHeight();
+
+            this.overlay.draw("rect")
+                .fill("#dedede")
+                .size(width, height);
+
+            for (let c = 0; c < this.columns; c++) {
+                const [x, ] = this.cellToCoord(c, 0);
+                this.overlay.draw("line")
+                    .stroke("#898989")
+                    .strokeWidth(1)
+                    .at(x, 0, x, height);
+            }
+
+            for (let r = 0; r < this.rows; r++) {
+                const [, y] = this.cellToCoord(0, r);
+                this.overlay.draw("line")
+                    .stroke("#898989")
+                    .strokeWidth(1)
+                    .at(0, y, width, y);
+            }
+
+            fade(this.overlay, 500, 500);
         }
     }
 
@@ -54,5 +102,30 @@ namespace mkcd {
         defaultProps.numCells = bitmap.width * bitmap.height;
 
         return mergeProps<GridProps>(defaultProps, props);
+    }
+
+    function fade(target: svg.Group, delay: number, duration: number) {
+        const start = Date.now() + delay;
+        const end = start + duration;
+        const slope = 1 / duration;
+
+        const frame = () => {
+            const now = Date.now();
+            if (now < end) {
+                const v = 1 - (slope * (now - start));
+                target.setAttribute("fill-opacity", v);
+                target.setAttribute("stroke-opacity", v);
+                requestAnimationFrame(frame);
+            }
+            else {
+                target.setAttribute("fill-opacity", 0)
+                target.setAttribute("stroke-opacity", 0)
+            }
+        }
+
+        target.setAttribute("fill-opacity", 1)
+        target.setAttribute("stroke-opacity", 1)
+
+        setTimeout(() => requestAnimationFrame(frame), delay);
     }
 }

--- a/editor/bitmapImage.ts
+++ b/editor/bitmapImage.ts
@@ -111,7 +111,7 @@ namespace mkcd {
                 .alignmentBaseline("middle")
                 .anchor("middle");
 
-            this.overlayFade = new Fade(this.overlay, 1000, 500);
+            this.overlayFade = new Fade(this.overlay, 750, 500);
         }
     }
 

--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -1,28 +1,23 @@
 namespace mkcd {
     import svg = svgUtil;
 
-    export interface IconButtonProps {
+    export interface ButtonProps {
         width: number;
         height: number;
-
-        iconString: string;
-        iconFont: string;
-        iconMargin: number;
         cornerRadius: number;
-
         backgroundClass?: string;
-        iconClass?: string;
         rootClass?: string;
+
+        padding: number;
     }
 
-    export class IconButton {
+    export class Button {
         protected root: svg.Group;
         protected background: svg.Rect;
-        protected icon: svg.Text;
 
         protected clickHandler: () => void;
 
-        constructor (protected props: IconButtonProps) {
+        constructor (protected props: ButtonProps) {
             this.buildDom();
         }
 
@@ -46,15 +41,17 @@ namespace mkcd {
             this.root.removeClass(className);
         }
 
+        public setDimensions(width: number, height: number) {
+            this.props.width = width;
+            this.props.height = height;
+            this.layout();
+        }
+
         protected buildDom() {
             this.root = new svg.Group();
 
             this.background = this.root.draw("rect")
-                .at(0, 0)
-                .corner(this.props.cornerRadius)
-                .size(this.props.width, this.props.height);
-
-            this.icon = this.drawIcon();
+                .corner(this.props.cornerRadius);
 
             if (this.props.rootClass) {
                 this.root.setClass(this.props.rootClass);
@@ -62,14 +59,21 @@ namespace mkcd {
             if (this.props.backgroundClass) {
                 this.background.setClass(this.props.backgroundClass);
             }
-            if (this.props.iconClass) {
-                this.icon.setClass(this.props.iconClass);
-            }
+
+            this.drawContent();
 
             this.root.el.addEventListener("click", () => {
                 this.handleClick();
             });
+
+            this.layout();
         }
+
+        // To be overridden by subclass
+        protected drawContent() {  }
+
+        // To be overridden by subclass
+        protected layoutContent(contentWidth: number, contentHeight: number, top: number, left: number) {  }
 
         protected handleClick() {
             if (this.clickHandler) {
@@ -77,14 +81,69 @@ namespace mkcd {
             }
         }
 
-        protected drawIcon(): svg.Text {
-            return this.root.draw("text")
-                .at(this.props.width / 2, this.props.height / 2)
+        protected layout() {
+            this.background.size(this.props.width, this.props.height);
+            const contentWidth = this.props.width - this.props.padding * 2;
+            const contentHeight = this.props.height - this.props.padding * 2;
+            this.layoutContent(contentWidth, contentHeight, this.props.padding, this.props.padding);
+        }
+    }
+
+    export interface FontIconButtonProps extends ButtonProps {
+        iconString: string;
+        iconFont: string;
+        iconClass?: string;
+    }
+
+    export class FontIconButton extends Button {
+        protected icon: svg.Text;
+
+        constructor (protected props: FontIconButtonProps) {
+            super(props);
+        }
+
+        protected drawContent() {
+            this.icon = this.root.draw("text")
                 .fontFamily(this.props.iconFont)
                 .text(this.props.iconString)
-                .fontSize(this.props.height - this.props.iconMargin * 2, svg.LengthUnit.px)
                 .anchor("middle")
                 .alignmentBaseline("middle");
+
+            if (this.props.iconClass) {
+                this.icon.setClass(this.props.iconClass);
+            }
+        }
+
+        protected layoutContent(contentWidth: number, contentHeight: number, top: number, left: number) {
+            this.icon.at(left + contentWidth / 2, top + contentHeight / 2)
+                .fontSize(contentHeight, svg.LengthUnit.px);
+        }
+    }
+
+    export interface CursorButtonProps extends ButtonProps {
+        cursorSideLength: number;
+        cursorFill: string;
+    }
+
+    export class CursorSizeButton extends Button {
+        protected cursor: svg.Rect;
+
+        constructor (protected props: CursorButtonProps) {
+            super(props);
+        }
+
+        protected drawContent() {
+            this.cursor = this.root.draw("rect")
+                .fill(this.props.cursorFill)
+        }
+
+        protected layoutContent(contentWidth: number, contentHeight: number, top: number, left: number) {
+
+            const unit = Math.min(contentWidth, contentHeight) / 4;
+
+            const sideLength = this.props.cursorSideLength * unit;
+            this.cursor.at(left + contentWidth / 2 - sideLength / 2, top + contentHeight / 2 - sideLength / 2)
+                .size(sideLength, sideLength);
         }
     }
 }

--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -54,14 +54,7 @@ namespace mkcd {
                 .corner(this.props.cornerRadius)
                 .size(this.props.width, this.props.height);
 
-            this.icon = this.root.draw("text")
-                .at(this.props.width / 2, this.props.height / 2)
-                .fontFamily(this.props.iconFont)
-                .text(this.props.iconString)
-                .fontSize(this.props.height - this.props.iconMargin * 2, svg.LengthUnit.px)
-                .anchor("middle")
-                .alignmentBaseline("middle");
-
+            this.icon = this.drawIcon();
 
             if (this.props.rootClass) {
                 this.root.setClass(this.props.rootClass);
@@ -74,10 +67,24 @@ namespace mkcd {
             }
 
             this.root.el.addEventListener("click", () => {
-                if (this.clickHandler) {
-                    this.clickHandler();
-                }
+                this.handleClick();
             });
+        }
+
+        protected handleClick() {
+            if (this.clickHandler) {
+                this.clickHandler();
+            }
+        }
+
+        protected drawIcon(): svg.Text {
+            return this.root.draw("text")
+                .at(this.props.width / 2, this.props.height / 2)
+                .fontFamily(this.props.iconFont)
+                .text(this.props.iconString)
+                .fontSize(this.props.height - this.props.iconMargin * 2, svg.LengthUnit.px)
+                .anchor("middle")
+                .alignmentBaseline("middle");
         }
     }
 }

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -7,31 +7,44 @@
 namespace mkcd {
     import svg = svgUtil;
 
-    const MARGIN = 8;
-    const CELL_WIDTH = 10;
-    const BG_WIDTH = 6;
+    // Absolute editor height
+    const TOTAL_HEIGHT = 250;
 
-    // Border around paint surface
-    const paintSurfaceBorderWidth = 0;
+    // Editor padding on all sides
+    const PADDING = 8;
 
-    // Border around color palette
-    const paletteBorderWidth = 2;
+    // Height of toolbar (the buttons above the canvas)
+    const TOOLBAR_HEIGHT = 25;
 
-    // Spacing between palette and screen (discounting borders)
-    const palettePaintMargin = 2;
+    // Spacing between the toolbar and the canvas
+    const TOOLBAR_CANVAS_MARGIN = 10;
+
+    // Total allowed height of paint surface
+    const CANVAS_HEIGHT = TOTAL_HEIGHT - TOOLBAR_HEIGHT - TOOLBAR_CANVAS_MARGIN - PADDING * 2;
+
+    // Border width between palette swatches
+    const PALETTE_INNER_BORDER = 2;
+
+    // Border width around the outside of the palette
+    const PALETTE_OUTER_BORDER = 3;
+
+    // Spacing between palette and paint surface
+    const PALETTE_CANVAS_MARGIN = 0;
 
     export class SpriteEditor implements ToolbarHost {
+        private group: svg.Group;
+        private root: svg.SVG;
+        private debugText: svg.Text;
+
         private palette: ColorPalette;
         private paintSurface: BitmapImage;
         private preview: BitmapImage;
         private toolbar: Toolbar;
 
-        private group: svg.Group;
-        private root: svg.SVG;
-        private debugText: svg.Text;
-
         private state: Bitmap;
-        private displayState: Bitmap;
+
+        // When changing the size, keep the old bitmap around so that we can restore it
+        private cachedState: Bitmap;
 
         private edit: Edit;
         private activeTool: PaintTool = PaintTool.Normal;
@@ -45,6 +58,7 @@ namespace mkcd {
 
         private width: number;
         private height: number;
+        private previewWidth: number;
 
         constructor(bitmap: Bitmap) {
             this.colors =  [
@@ -69,7 +83,6 @@ namespace mkcd {
             this.rows = bitmap.height;
 
             this.state = bitmap.copy()
-            this.displayState = bitmap.copy();
 
             this.root = new svg.SVG();
             this.group = this.root.group();
@@ -79,20 +92,18 @@ namespace mkcd {
                 rowLength: 2,
                 emptySwatchDisabled: false,
                 emptySwatchFill: 'url("#alpha-background")',
-                outerMargin: paletteBorderWidth,
-                columnMargin: 1,
-                rowMargin: 1,
+                outerMargin: PALETTE_OUTER_BORDER,
+                columnMargin: PALETTE_INNER_BORDER,
+                rowMargin: PALETTE_INNER_BORDER,
                 backgroundFill: "black",
                 colors: this.colors
             });
 
             this.paintSurface = new mkcd.BitmapImage({
-                cellWidth: CELL_WIDTH,
-                cellHeight: CELL_WIDTH,
-                outerMargin: paintSurfaceBorderWidth,
+                outerMargin: 0,
                 backgroundFill: "white",
                 cellClass: "pixel-cell"
-            }, this.displayState, ['url("#alpha-background")'].concat(this.colors));
+            }, this.state.copy(), ['url("#alpha-background")'].concat(this.colors));
 
             this.paintSurface.drag((col, row) => {
                 if (this.activeTool !== PaintTool.Fill) {
@@ -121,8 +132,8 @@ namespace mkcd {
             this.group.appendChild(this.palette.getView());
 
             this.toolbar = new Toolbar(this.group.group(), {
-                height: 25,
-                width: this.paintSurface.outerWidth()
+                height: TOOLBAR_HEIGHT,
+                width: CANVAS_HEIGHT
             }, this);
             this.palette.setSelected(1);
 
@@ -154,7 +165,7 @@ namespace mkcd {
         }
 
         render(el: HTMLElement): void {
-            this.root.attr({ "width": "95%", "height": "95%" });
+            this.root.attr({ "width": "100%", "height": "100%" });
             el.appendChild(this.root.el);
             this.layout();
         }
@@ -164,22 +175,25 @@ namespace mkcd {
                 return;
             }
 
-            const toolbarHeight = this.toolbar.outerHeight() + 10;
-            this.toolbar.translate(MARGIN, MARGIN);
+            const paintAreaTop = TOOLBAR_HEIGHT + TOOLBAR_CANVAS_MARGIN + PADDING;
 
-            const paletteScale = this.paintSurface.outerHeight() / this.palette.outerHeight();
-            this.palette.scale(paletteScale);
+            this.palette.setGridDimensions(CANVAS_HEIGHT);
+            this.palette.translate(PADDING, paintAreaTop);
 
-            this.palette.translate(MARGIN, MARGIN + toolbarHeight);
+            const paintAreaLeft = PADDING + this.palette.outerWidth() + PALETTE_CANVAS_MARGIN;
 
-            const paintLeft = MARGIN + this.palette.outerWidth() * paletteScale - paletteBorderWidth - paintSurfaceBorderWidth + palettePaintMargin;
-            this.paintSurface.translate(paintLeft, MARGIN + toolbarHeight);
+            this.paintSurface.setGridDimensions(CANVAS_HEIGHT);
+            const canvasLeft = paintAreaLeft + CANVAS_HEIGHT / 2 - this.paintSurface.outerWidth() / 2;
+            this.paintSurface.translate(canvasLeft, paintAreaTop);
 
-            this.width = paintLeft + this.paintSurface.outerWidth() + MARGIN;
-            this.height = this.paintSurface.outerHeight() + MARGIN * 2 + toolbarHeight;
+            this.width = paintAreaLeft + CANVAS_HEIGHT + PADDING;
+            this.height = paintAreaTop + CANVAS_HEIGHT + PADDING;
+
+            this.toolbar.translate(PADDING, PADDING);
+            this.toolbar.setDimensions(this.width - PADDING * 2, TOOLBAR_HEIGHT);
 
             if (this.debugText) {
-                this.debugText.at(paintLeft, this.paintSurface.outerHeight() + MARGIN * 2);
+                this.debugText.at(paintAreaLeft, this.height - PADDING);
             }
         }
 
@@ -193,6 +207,7 @@ namespace mkcd {
 
         setPreview(preview: BitmapImage) {
             this.preview = preview;
+            this.previewWidth = this.preview.outerWidth();
         }
 
         rePaint() {
@@ -224,6 +239,24 @@ namespace mkcd {
             }
         }
 
+        resize(width: number, height: number) {
+            if (!this.cachedState) {
+                this.cachedState = this.state.copy();
+                this.undoStack.push(this.cachedState)
+                this.redoStack = [];
+            }
+            this.columns = width;
+            this.rows = height;
+
+            this.state = resizeBitmap(this.cachedState, width, height);
+            this.paintSurface.restore(this.state, true);
+            this.paintSurface.setGridDimensions(CANVAS_HEIGHT);
+            this.paintSurface.showOverlay();
+            this.preview.restore(this.state, true);
+            this.preview.setGridDimensions(this.previewWidth);
+            this.layout();
+        }
+
         private paintEdit(edit: Edit) {
             this.paintSurface.restore(this.state);
             this.paintSurface.applyEdit(edit);
@@ -236,9 +269,12 @@ namespace mkcd {
 
         private commit() {
             if (this.edit) {
+                if (this.cachedState) {
+                    this.cachedState = undefined;
+                }
                 this.pushState(true);
                 this.paintEdit(this.edit);
-                this.state.apply(this.displayState);
+                this.state.apply(this.paintSurface.image);
                 this.edit = undefined;
                 this.redoStack = [];
             }
@@ -327,12 +363,12 @@ namespace mkcd {
             this.root.define(defs => {
                 const p = defs.create("pattern", "alpha-background")
                     .size(10, 10)
-                    .units(svg.PatternUnits.objectBoundingBox);
+                    .units(svg.PatternUnits.userSpaceOnUse);
 
                 p.draw("rect")
                     .at(0, 0)
-                    .size(11, 11)
-                    .fill("white")
+                    .size(10, 10)
+                    .fill("white");
                 p.draw("rect")
                     .at(0, 0)
                     .size(5, 5)

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -101,9 +101,9 @@ namespace mkcd {
 
             this.paintSurface = new mkcd.BitmapImage({
                 outerMargin: 0,
-                backgroundFill: "white",
+                backgroundFill: 'url("#alpha-background")',
                 cellClass: "pixel-cell"
-            }, this.state.copy(), ['url("#alpha-background")'].concat(this.colors));
+            }, this.state.copy(), [null].concat(this.colors), this.root);
 
             this.paintSurface.drag((col, row) => {
                 if (this.activeTool !== PaintTool.Fill) {

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -8,16 +8,16 @@ namespace mkcd {
     import svg = svgUtil;
 
     // Absolute editor height
-    const TOTAL_HEIGHT = 250;
+    const TOTAL_HEIGHT = 270;
 
     // Editor padding on all sides
     const PADDING = 8;
 
     // Height of toolbar (the buttons above the canvas)
-    const TOOLBAR_HEIGHT = 25;
+    const TOOLBAR_HEIGHT = 45;
 
     // Spacing between the toolbar and the canvas
-    const TOOLBAR_CANVAS_MARGIN = 10;
+    const TOOLBAR_CANVAS_MARGIN = 5;
 
     // Total allowed height of paint surface
     const CANVAS_HEIGHT = TOTAL_HEIGHT - TOOLBAR_HEIGHT - TOOLBAR_CANVAS_MARGIN - PADDING * 2;
@@ -48,6 +48,7 @@ namespace mkcd {
 
         private edit: Edit;
         private activeTool: PaintTool = PaintTool.Normal;
+        private toolWidth = 1;
 
         private undoStack: Bitmap[] = [];
         private redoStack: Bitmap[] = [];
@@ -133,7 +134,10 @@ namespace mkcd {
 
             this.toolbar = new Toolbar(this.group.group(), {
                 height: TOOLBAR_HEIGHT,
-                width: CANVAS_HEIGHT
+                width: CANVAS_HEIGHT,
+                buttonMargin: 5,
+                optionsMargin: 3,
+                rowMargin: 5
             }, this);
             this.palette.setSelected(1);
 
@@ -205,9 +209,9 @@ namespace mkcd {
             return this.height;
         }
 
-        setPreview(preview: BitmapImage) {
+        setPreview(preview: BitmapImage, width: number) {
             this.preview = preview;
-            this.previewWidth = this.preview.outerWidth();
+            this.previewWidth = width;
         }
 
         rePaint() {
@@ -219,6 +223,10 @@ namespace mkcd {
 
         setActiveTool(tool: PaintTool) {
             this.activeTool = tool;
+        }
+
+        setToolWidth(width: number) {
+            this.toolWidth = width;
         }
 
         undo() {
@@ -255,6 +263,14 @@ namespace mkcd {
             this.preview.restore(this.state, true);
             this.preview.setGridDimensions(this.previewWidth);
             this.layout();
+        }
+
+        canvasWidth() {
+            return this.columns;
+        }
+
+        canvasHeight() {
+            return this.rows;
         }
 
         private paintEdit(edit: Edit) {
@@ -309,12 +325,12 @@ namespace mkcd {
 
         private newEdit(color: number) {
             switch (this.activeTool) {
-                case PaintTool.Normal: return new PaintEdit(this.columns, this.rows, color);
-                case PaintTool.Rectangle: return new RectangleEdit(this.columns, this.rows, color);
-                case PaintTool.Outline: return new OutlineEdit(this.columns, this.rows, color);
-                case PaintTool.Line: return new LineEdit(this.columns, this.rows, color);
-                case PaintTool.Circle: return new CircleEdit(this.columns, this.rows, color);
-                case PaintTool.Erase: return new PaintEdit(this.columns, this.rows, 0);
+                case PaintTool.Normal: return new PaintEdit(this.columns, this.rows, color, this.toolWidth);
+                case PaintTool.Rectangle: return new RectangleEdit(this.columns, this.rows, color, this.toolWidth);
+                case PaintTool.Outline: return new OutlineEdit(this.columns, this.rows, color, this.toolWidth);
+                case PaintTool.Line: return new LineEdit(this.columns, this.rows, color, this.toolWidth);
+                case PaintTool.Circle: return new CircleEdit(this.columns, this.rows, color, this.toolWidth);
+                case PaintTool.Erase: return new PaintEdit(this.columns, this.rows, 0, this.toolWidth);
 
                 // TODO: Doesn't really need to be a special case
                 case PaintTool.Fill: return undefined;

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -165,9 +165,9 @@ namespace mkcd {
         }
 
         render(el: HTMLElement): void {
-            this.root.attr({ "width": "100%", "height": "100%" });
             el.appendChild(this.root.el);
             this.layout();
+            this.root.attr({ "width": this.outerWidth() + "px", "height": this.outerHeight() + "px" });
         }
 
         layout(): void {

--- a/editor/spriteFieldEditor.ts
+++ b/editor/spriteFieldEditor.ts
@@ -5,9 +5,14 @@
 
 
 namespace pxt.editor {
-    const PREVIEW_WIDTH = 40;
-    const PREVIEW_HEIGHT = 40;
-    const TOP_BOTTOM_MARGIN = 5;
+    import svg = svgUtil;
+
+    // It's a square
+    const TOTAL_WIDTH = 55;
+    const PADDING = 5;
+    const BG_PADDING = 4;
+    const BG_WIDTH = TOTAL_WIDTH - PADDING * 2;
+    const PREVIEW_WIDTH = TOTAL_WIDTH - PADDING * 2 - BG_PADDING * 2;
 
     // These are the characters used to compile, for a list of every supported character see parseBitmap()
     const hexChars = [".", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"];
@@ -66,8 +71,6 @@ namespace pxt.editor {
             this.editor.render(contentDiv);
             this.editor.rePaint();
 
-            goog.style.setHeight(contentDiv, this.editor.outerHeight());
-            goog.style.setWidth(contentDiv, this.editor.outerWidth());
 
             Blockly.DropDownDiv.setColour("#2c3e50", "#2c3e50");
             Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_, () => {
@@ -77,10 +80,14 @@ namespace pxt.editor {
                         this.sourceBlock_, 'field', this.name, this.text_, this.getText()));
                 }
 
-                goog.style.setHeight(contentDiv, "unset");
-                goog.style.setWidth(contentDiv, "unset");
+                goog.style.setHeight(contentDiv, null);
+                goog.style.setWidth(contentDiv, null);
+                goog.style.setStyle(contentDiv, "overflow", null);
             });
             this.editor.layout();
+            goog.style.setHeight(contentDiv, this.editor.outerHeight() + 1);
+            goog.style.setWidth(contentDiv, this.editor.outerWidth() + 1);
+            goog.style.setStyle(contentDiv, "overflow", "hidden");
         }
 
 
@@ -91,8 +98,8 @@ namespace pxt.editor {
         render_() {
             super.render_();
             if (this.preview) {
-                this.size_.height = this.preview.outerHeight() + TOP_BOTTOM_MARGIN * 2;
-                this.size_.width = this.preview.outerWidth() + TOP_BOTTOM_MARGIN * 2;
+                this.size_.height = TOTAL_WIDTH
+                this.size_.width = TOTAL_WIDTH;
             }
         }
 
@@ -129,6 +136,14 @@ namespace pxt.editor {
 
         private redrawPreview() {
             this.fieldGroup_.innerHTML = "";
+
+            const bg = new svg.Rect()
+                .at(PADDING, PADDING)
+                .size(BG_WIDTH, BG_WIDTH)
+                .fill("#dedede")
+                .stroke("#898989", 1)
+                .corner(4);
+
             this.preview = new mkcd.BitmapImage({
                 //backgroundFill: this.sourceBlock_.getColourSecondary(),
                 outerMargin: 2,
@@ -152,8 +167,9 @@ namespace pxt.editor {
                     "#000000", // black
                 ]);
 
-            this.preview.translate(0, TOP_BOTTOM_MARGIN);
+            this.preview.translate(PADDING + BG_PADDING, PADDING + BG_PADDING);
             this.preview.setGridDimensions(PREVIEW_WIDTH);
+            this.fieldGroup_.appendChild(bg.el);
             this.fieldGroup_.appendChild(this.preview.getView().el);
         }
 

--- a/editor/spriteFieldEditor.ts
+++ b/editor/spriteFieldEditor.ts
@@ -71,6 +71,7 @@ namespace pxt.editor {
 
             Blockly.DropDownDiv.setColour("#2c3e50", "#2c3e50");
             Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_, () => {
+                this.state = this.preview.image;
                 if (this.sourceBlock_ && Blockly.Events.isEnabled()) {
                     Blockly.Events.fire(new Blockly.Events.BlockChange(
                         this.sourceBlock_, 'field', this.name, this.text_, this.getText()));
@@ -131,8 +132,6 @@ namespace pxt.editor {
             this.preview = new mkcd.BitmapImage({
                 //backgroundFill: this.sourceBlock_.getColourSecondary(),
                 outerMargin: 2,
-                cellWidth: Math.floor(PREVIEW_WIDTH / 16),
-                cellHeight: Math.floor(PREVIEW_HEIGHT / 16),
                 cellClass: "pixel-cell"
             }, this.state, [
                     "rgba(0, 0, 0, 0)",
@@ -154,6 +153,7 @@ namespace pxt.editor {
                 ]);
 
             this.preview.translate(0, TOP_BOTTOM_MARGIN);
+            this.preview.setGridDimensions(PREVIEW_WIDTH);
             this.fieldGroup_.appendChild(this.preview.getView().el);
         }
 

--- a/editor/spriteFieldEditor.ts
+++ b/editor/spriteFieldEditor.ts
@@ -67,7 +67,7 @@ namespace pxt.editor {
             let contentDiv = Blockly.DropDownDiv.getContentDiv();
 
             this.editor = new mkcd.SpriteEditor(this.preview.bitmap());
-            this.editor.setPreview(this.preview);
+            this.editor.setPreview(this.preview, PREVIEW_WIDTH);
             this.editor.render(contentDiv);
             this.editor.rePaint();
 

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -42,16 +42,16 @@ namespace mkcd {
         }
 
         protected createButtons() {
-            this.pencilButton = this.addTool("\uf303", PaintTool.Normal);
-            this.rectButton = this.addTool("\uf360", PaintTool.Rectangle);
+            this.pencilButton = this.addTool("\uf040", PaintTool.Normal);
+            this.rectButton = this.addTool("\uf096", PaintTool.Rectangle);
             this.eraseButton = this.addTool("\uf12d", PaintTool.Erase);
 
-            this.undoButton = this.addButton("\uf2ea");
+            this.undoButton = this.addButton("\uf0e2");
             this.undoButton.onClick(() => {
                 this.host.undo();
             });
 
-            this.redoButton = this.addButton("\uf2f9");
+            this.redoButton = this.addButton("\uf01e");
             this.redoButton.onClick(() => {
                 this.host.redo();
             });

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -56,7 +56,7 @@ namespace mkcd {
                 this.host.redo();
             });
 
-            this.resizeButton = this.addButton("\uf337");
+            this.resizeButton = this.addButton("\uf0b2");
             this.resizeButton.onClick(() => {
                 this.selectedSize = (this.selectedSize + 1) % sizePresets.length;
                 const [width, height] = sizePresets[this.selectedSize];

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -7,13 +7,20 @@ namespace mkcd {
     export interface ToolbarProps {
         width: number;
         height: number;
+        buttonMargin: number;
+        optionsMargin: number;
+        rowMargin: number;
     }
 
     export interface ToolbarHost {
         setActiveTool(tool: PaintTool): void;
+        setToolWidth(width: number): void;
         undo(): void;
         redo(): void;
         resize(width: number, height: number): void;
+
+        canvasWidth(): number;
+        canvasHeight(): number;
     }
 
     const sizePresets: [number, number][] = [
@@ -24,60 +31,47 @@ namespace mkcd {
         [32, 32],
     ];
 
+    // The ratio of the toolbar height that is taken up by the options (as opposed to the buttons)
+    const TOOLBAR_OPTIONS_RATIO = 0.33333333;
+
     export class Toolbar {
         protected activeTool = PaintTool.Normal;
+        protected toolWidth = 1;
 
-        protected pencilButton: IconButton;
-        protected rectButton: IconButton;
-        protected eraseButton: IconButton;
+        protected optionBar: svg.Group;
+        protected toolsBar: svg.Group;
 
-        protected undoButton: IconButton;
-        protected redoButton: IconButton;
+        protected pencilButton: FontIconButton;
+        protected rectButton: FontIconButton;
+        protected eraseButton: FontIconButton;
+        protected fillButton: FontIconButton;
 
-        protected resizeButton: IconButton;
+        protected undoButton: FontIconButton;
+        protected redoButton: FontIconButton;
+
+        protected resizeButton: FontIconButton;
+        protected cursorSizes: CursorSizeButton[];
         protected selectedSize = 2;
 
+        protected toolbarHeight: number;
+        protected optionsHeight: number;
+
         constructor(protected g: svg.Group, protected props: ToolbarProps, protected host: ToolbarHost) {
+            this.toolsBar = g.group();
+            this.optionBar = g.group();
+
+            const canvasColumns = this.host.canvasWidth();
+            const canvasRows = this.host.canvasHeight();
+            sizePresets.forEach(([columns, rows], index) => {
+                if (columns === canvasColumns && rows === canvasRows) {
+                    this.selectedSize = index;
+                }
+            });
+
+
             this.createButtons();
-        }
-
-        protected createButtons() {
-            this.pencilButton = this.addTool("\uf040", PaintTool.Normal);
-            this.rectButton = this.addTool("\uf096", PaintTool.Rectangle);
-            this.eraseButton = this.addTool("\uf12d", PaintTool.Erase);
-
-            this.undoButton = this.addButton("\uf0e2");
-            this.undoButton.onClick(() => {
-                this.host.undo();
-            });
-
-            this.redoButton = this.addButton("\uf01e");
-            this.redoButton.onClick(() => {
-                this.host.redo();
-            });
-
-            this.resizeButton = this.addButton("\uf0b2");
-            this.resizeButton.onClick(() => {
-                this.selectedSize = (this.selectedSize + 1) % sizePresets.length;
-                const [width, height] = sizePresets[this.selectedSize];
-                this.host.resize(width, height);
-            });
-
-            this.setTool(PaintTool.Normal);
+            this.createOptionsBar();
             this.layout();
-        }
-
-        protected addTool(icon: string, tool: PaintTool) {
-            const toolBtn = this.addButton(icon);
-            toolBtn.onClick(() => this.setTool(tool));
-            return toolBtn;
-        }
-
-        protected addButton(icon: string) {
-            const btn = mkToolbarButton(icon, this.props.height);
-            this.g.appendChild(btn.getView());
-
-            return btn;
         }
 
         outerWidth() {
@@ -100,21 +94,89 @@ namespace mkcd {
             }
         }
 
-        protected layout() {
-            this.layoutButton(this.pencilButton, 0, true);
-            this.layoutButton(this.rectButton, 1, true);
-            this.layoutButton(this.eraseButton, 2, true);
-            this.layoutButton(this.undoButton, 3, true);
-            this.layoutButton(this.redoButton, 4, true);
-            this.layoutButton(this.resizeButton, 0, false);
+        protected createButtons() {
+            this.pencilButton = this.addTool("\uf040", PaintTool.Normal);
+            this.rectButton = this.addTool("\uf096", PaintTool.Rectangle);
+            this.eraseButton = this.addTool("\uf12d", PaintTool.Erase);
+            this.fillButton = this.addTool("\uf0d0", PaintTool.Fill);
+
+            this.undoButton = this.addButton("\uf0e2");
+            this.undoButton.onClick(() => {
+                this.host.undo();
+            });
+
+            this.redoButton = this.addButton("\uf01e");
+            this.redoButton.onClick(() => {
+                this.host.redo();
+            });
+
+            this.resizeButton = this.addButton("\uf0b2");
+            this.resizeButton.onClick(() => {
+                this.selectedSize = (this.selectedSize + 1) % sizePresets.length;
+                const [width, height] = sizePresets[this.selectedSize];
+                this.host.resize(width, height);
+            });
+
+            this.setTool(PaintTool.Normal);
         }
 
-        protected layoutButton(button: IconButton, index: number, fromLeft: boolean) {
+        protected createOptionsBar() {
+            this.cursorSizes = []
+            for (let i = 0; i < 4; i++) {
+                const btn = mkCursorSizeButton(i + 1, this.props.height);
+                this.cursorSizes.push(btn);
+                this.optionBar.appendChild(btn.getView());
+                btn.onClick(() => {
+                    this.setToolWidth(i + 1);
+                });
+            }
+            this.setToolWidth(1);
+        }
+
+        protected layoutOptionsBar() {
+            this.cursorSizes.forEach((button, i) => {
+                button.setDimensions(this.optionsHeight, this.optionsHeight);
+                button.translate(i * (this.optionsHeight + this.props.optionsMargin), 0);
+            });
+        }
+
+        protected addTool(icon: string, tool: PaintTool) {
+            const toolBtn = this.addButton(icon);
+            toolBtn.onClick(() => this.setTool(tool));
+            return toolBtn;
+        }
+
+        protected addButton(icon: string) {
+            const btn = mkToolbarButton(icon, this.props.height);
+            this.toolsBar.appendChild(btn.getView());
+
+            return btn;
+        }
+
+        protected layout() {
+            this.optionsHeight = TOOLBAR_OPTIONS_RATIO * this.props.height;
+            this.toolbarHeight = this.props.height - this.optionsHeight - this.props.rowMargin;
+            this.layoutButton(this.pencilButton, 0, true);
+            this.layoutButton(this.eraseButton, 1, true);
+            this.layoutButton(this.fillButton, 2, true);
+            this.layoutButton(this.rectButton, 3, true);
+
+            this.layoutButton(this.undoButton, 2, false);
+            this.layoutButton(this.redoButton, 1, false);
+            this.layoutButton(this.resizeButton, 0, false);
+
+            // this.toolsBar.translate(0, this.optionsHeight + this.props.rowMargin);
+            this.optionBar.translate(0, this.toolbarHeight + this.props.rowMargin);
+            this.layoutOptionsBar();
+        }
+
+        protected layoutButton(button: FontIconButton, index: number, fromLeft: boolean) {
+            button.setDimensions(this.toolbarHeight, this.toolbarHeight);
             if (fromLeft) {
-                button.translate(index * (this.props.height + 5), 0);
+                button.translate(index * (this.toolbarHeight + this.props.buttonMargin), 0);
             }
             else {
-                button.translate(this.props.width - (index + 1) * (this.props.height + 5), 0);
+                button.translate(this.props.width - (index + 1) * (this.toolbarHeight + this.props.buttonMargin), 0);
             }
         }
 
@@ -125,8 +187,15 @@ namespace mkcd {
             this.highlightTool(this.activeTool, true);
         }
 
+        protected setToolWidth(width: number) {
+            this.cursorSizes[this.toolWidth - 1].removeClass("toolbar-button-selected")
+            this.toolWidth = width;
+            this.host.setToolWidth(width);
+            this.cursorSizes[this.toolWidth - 1].addClass("toolbar-button-selected")
+        }
+
         protected highlightTool(tool: PaintTool, highlighted: boolean) {
-            let button: IconButton;
+            let button: FontIconButton;
             switch (tool) {
                 case PaintTool.Normal:
                     button = this.pencilButton;
@@ -150,12 +219,25 @@ namespace mkcd {
         }
     }
 
+    function mkCursorSizeButton(size: number, sideLength: number) {
+        return new CursorSizeButton({
+            width: sideLength,
+            height: sideLength,
+            padding: 2,
+            cornerRadius: 2,
+            rootClass: "toolbar-button",
+            backgroundClass: "toolbar-button-background",
+            cursorFill: "black",
+            cursorSideLength: size
+        });
+    }
+
     function mkToolbarButton(icon: string, sideLength: number) {
-        return new IconButton({
+        return new FontIconButton({
             width: sideLength,
             height: sideLength,
             cornerRadius: 2,
-            iconMargin: sideLength / 5,
+            padding: 4,
             iconFont: "Icons",
             iconString: icon,
             rootClass: "toolbar-button",

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -206,6 +206,9 @@ namespace mkcd {
                 case PaintTool.Erase:
                     button = this.eraseButton;
                     break;
+                case PaintTool.Fill:
+                    button = this.fillButton;
+                    break;
             }
 
             if (button) {

--- a/editor/tools.ts
+++ b/editor/tools.ts
@@ -15,7 +15,7 @@ namespace mkcd {
         protected startCol: number;
         protected startRow: number;
 
-        constructor (protected canvasWidth: number, protected canvasHeight: number, protected color: number) {
+        constructor (protected canvasWidth: number, protected canvasHeight: number, protected color: number, protected toolWidth: number) {
         }
 
         public abstract update(col: number, row: number): void;
@@ -51,13 +51,22 @@ namespace mkcd {
     export class PaintEdit extends Edit {
         protected mask: Bitmask;
 
-        constructor (canvasWidth: number, canvasHeight: number, color: number) {
-            super(canvasWidth, canvasHeight, color);
+        constructor (canvasWidth: number, canvasHeight: number, color: number, toolWidth: number) {
+            super(canvasWidth, canvasHeight, color, toolWidth);
             this.mask = new mkcd.Bitmask(canvasWidth, canvasHeight);
         }
 
         update(col: number, row: number) {
-            this.mask.set(col, row);
+            for (let i = 0; i < this.toolWidth; i++) {
+                for (let j = 0; j < this.toolWidth; j++) {
+                    const c = col + i;
+                    const r = row + j;
+
+                    if (c < this.canvasWidth && r < this.canvasHeight) {
+                        this.mask.set(col + i, row + j);
+                    }
+                }
+            }
         }
 
         doEdit(bitmap: Bitmap) {

--- a/sim/svg.ts
+++ b/sim/svg.ts
@@ -232,6 +232,10 @@ namespace svgUtil {
             return this.setAttribute("stroke-opacity", opacity);
         }
 
+        setVisible(visible: boolean): this {
+            return this.setAttribute("visibility", visible ? "visible" : "hidden");
+        }
+
         onDown(handler: PointerHandler): this {
             events.down(this.el, handler);
             return this;

--- a/sim/svg.ts
+++ b/sim/svg.ts
@@ -297,12 +297,12 @@ namespace svgUtil {
     export class Rect extends Drawable<SVGRectElement> {
         constructor() { super("rect") };
 
-        width(width: number): this {
-            return this.setAttribute("width", width);
+        width(width: number, unit = LengthUnit.px): this {
+            return this.setAttribute("width", lengthWithUnits(width, unit));
         }
 
-        height(height: number): this {
-            return this.setAttribute("height", height);
+        height(height: number, unit = LengthUnit.px): this {
+            return this.setAttribute("height", lengthWithUnits(height, unit));
         }
 
         corner(radius: number): this {
@@ -315,9 +315,9 @@ namespace svgUtil {
             return this;
         }
 
-        size(width: number, height: number): this {
-            this.width(width);
-            this.height(height);
+        size(width: number, height: number, unit = LengthUnit.px): this {
+            this.width(width, unit);
+            this.height(height, unit);
             return this;
         }
     }


### PR DESCRIPTION
Fixes https://github.com/Microsoft/pxt-32/issues/43
![sprite_editor_v3](https://user-images.githubusercontent.com/13754588/37803518-6c130e96-2dec-11e8-9870-8d1e85613c1b.gif)


New features:

1. Tool size option
2. Canvas resizing
3. Fill tool (icon is a magic wand, will change later)
4. Background for sprite on the block
4. Lots of bug fixes and perf improvements