### PR TITLE
More sprite editor improvements

### DIFF
--- a/editor/bitmapImage.ts
+++ b/editor/bitmapImage.ts
@@ -31,6 +31,10 @@ namespace mkcd {
         writeColor(col: number, row: number, color: number) {
             const old = this.image.get(col, row);
             this.image.set(col, row, color);
+            this.drawColor(col, row, color);
+        }
+
+        drawColor(col: number, row: number, color: number) {
             this.setCellColor(col, row, this.palette[color]);
         }
 

--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -41,6 +41,10 @@ namespace mkcd {
             this.root.removeClass(className);
         }
 
+        public title(text: string) {
+            this.root.title(text);
+        }
+
         public setDimensions(width: number, height: number) {
             this.props.width = width;
             this.props.height = height;

--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -14,7 +14,7 @@ namespace mkcd {
     export class Button {
         protected root: svg.Group;
         protected background: svg.Rect;
-        protected enabled: boolean;
+        protected enabled = true;
 
         protected clickHandler: () => void;
 

--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -139,7 +139,7 @@ namespace mkcd {
 
         protected layoutContent(contentWidth: number, contentHeight: number, top: number, left: number) {
 
-            const unit = Math.min(contentWidth, contentHeight) / 4;
+            const unit = Math.min(contentWidth, contentHeight) / 3;
 
             const sideLength = this.props.cursorSideLength * unit;
             this.cursor.at(left + contentWidth / 2 - sideLength / 2, top + contentHeight / 2 - sideLength / 2)

--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -14,6 +14,7 @@ namespace mkcd {
     export class Button {
         protected root: svg.Group;
         protected background: svg.Rect;
+        protected enabled: boolean;
 
         protected clickHandler: () => void;
 
@@ -51,6 +52,19 @@ namespace mkcd {
             this.layout();
         }
 
+        public setEnabled(enabled: boolean) {
+            if (enabled != this.enabled) {
+                this.enabled = enabled;
+
+                if (this.enabled) {
+                    this.root.removeClass("disabled");
+                }
+                else {
+                    this.root.appendClass("disabled");
+                }
+            }
+        }
+
         protected buildDom() {
             this.root = new svg.Group();
 
@@ -80,7 +94,7 @@ namespace mkcd {
         protected layoutContent(contentWidth: number, contentHeight: number, top: number, left: number) {  }
 
         protected handleClick() {
-            if (this.clickHandler) {
+            if (this.clickHandler && this.enabled) {
                 this.clickHandler();
             }
         }

--- a/editor/grid.ts
+++ b/editor/grid.ts
@@ -139,6 +139,10 @@ namespace mkcd {
             }
         }
 
+        setRootId(id: string) {
+            this.group.id(id);
+        }
+
         down(handler: (col: number, row: number) => void): void {
             this.initDragSurface();
             this.gesture.subscribe(GestureType.Down, handler);

--- a/editor/grid.ts
+++ b/editor/grid.ts
@@ -375,7 +375,6 @@ namespace mkcd {
         }
 
         protected fire(type: GestureType) {
-            console.log("GESTURE: " + GestureType[type] + " c=" + this.lastCol + " r=" + this.lastRow);
             if (this.handlers[type]) {
                 this.handlers[type](this.lastCol, this.lastRow);
             }

--- a/editor/palette.ts
+++ b/editor/palette.ts
@@ -16,6 +16,7 @@ namespace mkcd {
     export class ColorPalette extends Grid {
         selected: number;
         private props: ColorPaletteProps;
+        private handler: (color: number) => void;
         private selectedClone: svg.BaseElement<SVGUseElement>;
 
         constructor(props: Partial<ColorPaletteProps>) {
@@ -50,6 +51,10 @@ namespace mkcd {
             this.setCellHighlighted(this.selected, false);
             this.selected = index;
             this.setCellHighlighted(this.selected, true);
+
+            if (this.handler) {
+                this.handler(this.selected);
+            }
         }
 
         selectedColor() {
@@ -65,6 +70,10 @@ namespace mkcd {
             else {
                 cell.setAttribute("class", this.props.unselectedClass);
             }
+        }
+
+        onColorSelected(handler: (color: number) => void) {
+            this.handler = handler;
         }
 
         protected initColors() {

--- a/editor/palette.ts
+++ b/editor/palette.ts
@@ -66,11 +66,13 @@ namespace mkcd {
         setCellHighlighted(index: number, highlighted: boolean)  {
             const cell = this.getCell(index);
             if (highlighted) {
-                cell.setAttribute("class", this.props.selectedClass);
+                cell.removeClass(this.props.unselectedClass);
+                cell.appendClass(this.props.selectedClass);
                 this.selectedClone.setAttribute("href", cell.el.getAttribute("id"))
             }
             else {
-                cell.setAttribute("class", this.props.unselectedClass);
+                cell.removeClass(this.props.selectedClass);
+                cell.appendClass(this.props.unselectedClass);
             }
         }
 

--- a/editor/palette.ts
+++ b/editor/palette.ts
@@ -4,6 +4,8 @@
 
 namespace mkcd {
     import svg = svgUtil;
+    import lf = pxt.Util.lf;
+
     export interface ColorPaletteProps extends GridStyleProps {
         colors: string[];
         rowLength: number;
@@ -79,6 +81,12 @@ namespace mkcd {
         protected initColors() {
             for (let i = 0; i < this.gridProps.numCells; i++) {
                 const cell = this.getCell(i);
+                if (i === 0) {
+                    cell.title(lf("Color Index 0 (Transparent)"));
+                }
+                else {
+                    cell.title(lf("Color Index {0}", i));
+                }
                 cell.fill(this.colorForIndex(i));
                 cell.onDown(() => this.setSelected(i));
                 this.setCellHighlighted(i, false);

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -125,6 +125,7 @@ namespace mkcd {
             this.paintSurface.drag((col, row) => {
                 this.debug("gesture (" + PaintTool[this.activeTool] + ")");
                 this.setCell(col, row, this.color, false);
+                this.setCursorInfo(col, row);
             });
 
             this.paintSurface.up((col, row) => {
@@ -138,6 +139,7 @@ namespace mkcd {
 
             this.paintSurface.move((col, row) => {
                 this.drawCursor(col, row);
+                this.setCursorInfo(col, row);
             });
 
             this.paintSurface.leave(() => {
@@ -344,7 +346,9 @@ namespace mkcd {
                 this.paintSurface.repaint();
                 this.edit.drawCursor(col, row, (c, r) => this.paintSurface.drawColor(c, r, this.edit.color));
             }
+        }
 
+        private setCursorInfo(col: number, row: number) {
             this.cursorInfo.text(`${col},${row}`);
         }
 

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -6,6 +6,7 @@
 
 namespace mkcd {
     import svg = svgUtil;
+    import lf = pxt.Util.lf;
 
     // Absolute editor height
     const TOTAL_HEIGHT = 350;
@@ -106,6 +107,7 @@ namespace mkcd {
                 backgroundFill: 'url("#alpha-background")',
                 cellClass: "pixel-cell"
             }, this.state.copy(), [null].concat(this.colors), this.root);
+
 
             this.paintSurface.drag((col, row) => {
                 if (this.activeTool !== PaintTool.Fill) {
@@ -232,6 +234,13 @@ namespace mkcd {
 
         setActiveColor(color: number) {
             this.color = color;
+
+            // If the user is erasing, go back to pencil
+            if (this.activeTool === PaintTool.Erase) {
+                this.toolbar.resetTool();
+                this.activeTool = PaintTool.Normal;
+            }
+
             this.edit = this.newEdit(this.color);
         }
 
@@ -357,7 +366,7 @@ namespace mkcd {
         private newEdit(color: number) {
             switch (this.activeTool) {
                 case PaintTool.Normal: return new PaintEdit(this.columns, this.rows, color, this.toolWidth);
-                case PaintTool.Rectangle: return new RectangleEdit(this.columns, this.rows, color, this.toolWidth);
+                case PaintTool.Rectangle: return new OutlineEdit(this.columns, this.rows, color, this.toolWidth);
                 case PaintTool.Outline: return new OutlineEdit(this.columns, this.rows, color, this.toolWidth);
                 case PaintTool.Line: return new LineEdit(this.columns, this.rows, color, this.toolWidth);
                 case PaintTool.Circle: return new CircleEdit(this.columns, this.rows, color, this.toolWidth);

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -291,13 +291,20 @@ namespace mkcd {
             this.rows = height;
 
             this.state = resizeBitmap(this.cachedState, width, height);
+
             this.paintSurface.restore(this.state, true);
             this.paintSurface.setGridDimensions(CANVAS_HEIGHT);
-            this.paintSurface.showOverlay();
+
             this.preview.restore(this.state, true);
             this.preview.setGridDimensions(this.previewWidth);
+
             this.canvasDimensions.text(`${this.columns}x${this.rows}`)
             this.layout();
+
+            this.paintSurface.showOverlay();
+
+            // Canvas size changed and some edits rely on that (like paint)
+            this.edit = this.newEdit(this.color);
         }
 
         canvasWidth() {

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -168,6 +168,7 @@ namespace mkcd {
             this.setActiveColor(this.color);
 
             this.drawReporterBar();
+            this.updateUndoRedo();
 
             document.addEventListener("keydown", ev => {
                 if (ev.key === "Undo" || (ev.ctrlKey && ev.key === "z")) {
@@ -267,6 +268,7 @@ namespace mkcd {
                 this.pushState(false);
                 this.restore(todo);
             }
+            this.updateUndoRedo();
         }
 
         redo() {
@@ -276,6 +278,7 @@ namespace mkcd {
                 this.pushState(true);
                 this.restore(todo);
             }
+            this.updateUndoRedo();
         }
 
         resize(width: number, height: number) {
@@ -369,6 +372,7 @@ namespace mkcd {
             else {
                 this.redoStack.push(cp);
             }
+            this.updateUndoRedo();
         }
 
         private restore(bitmap: Bitmap) {
@@ -378,6 +382,11 @@ namespace mkcd {
             if (this.preview) {
                 this.preview.restore(bitmap, true);
             }
+        }
+
+        private updateUndoRedo() {
+            this.toolbar.setUndoState(this.undoStack.length > 0);
+            this.toolbar.setRedoState(this.redoStack.length > 0);
         }
 
         private paintCell(col: number, row: number, color: number) {

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -14,14 +14,19 @@ namespace mkcd {
     // Editor padding on all sides
     const PADDING = 8;
 
+    const PADDING_BOTTOM = 3;
+
     // Height of toolbar (the buttons above the canvas)
     const TOOLBAR_HEIGHT = 55;
 
     // Spacing between the toolbar and the canvas
     const TOOLBAR_CANVAS_MARGIN = 5;
 
-    // Total allowed height of paint surface
-    const CANVAS_HEIGHT = TOTAL_HEIGHT - TOOLBAR_HEIGHT - TOOLBAR_CANVAS_MARGIN - PADDING * 2;
+    // Height of the bar that displays editor size and info below the canvas
+    const REPORTER_BAR_HEIGHT = 13;
+
+    // Spacing between the canvas and reporter bar
+    const REPORTER_BAR_CANVAS_MARGIN = 5;
 
     // Border width between palette swatches
     const PALETTE_INNER_BORDER = 2;
@@ -32,15 +37,21 @@ namespace mkcd {
     // Spacing between palette and paint surface
     const PALETTE_CANVAS_MARGIN = 0;
 
+    // Total allowed height of paint surface
+    const CANVAS_HEIGHT = TOTAL_HEIGHT - TOOLBAR_HEIGHT - TOOLBAR_CANVAS_MARGIN
+        - REPORTER_BAR_HEIGHT - REPORTER_BAR_CANVAS_MARGIN - PADDING * 2;
+
     export class SpriteEditor implements ToolbarHost {
         private group: svg.Group;
         private root: svg.SVG;
-        private debugText: svg.Text;
 
         private palette: ColorPalette;
         private paintSurface: BitmapImage;
         private preview: BitmapImage;
         private toolbar: Toolbar;
+        private repoterBar: svg.Group;
+        private cursorInfo: svg.Text;
+        private canvasDimensions: svg.Text;
 
         private state: Bitmap;
 
@@ -94,6 +105,7 @@ namespace mkcd {
             this.palette = new mkcd.ColorPalette({
                 rowLength: 2,
                 emptySwatchDisabled: false,
+                cellClass: "palette-swatch",
                 emptySwatchFill: 'url("#alpha-background")',
                 outerMargin: PALETTE_OUTER_BORDER,
                 columnMargin: PALETTE_INNER_BORDER,
@@ -101,35 +113,27 @@ namespace mkcd {
                 backgroundFill: "black",
                 colors: this.colors
             });
+            this.palette.setRootId("sprite-editor-palette");
 
             this.paintSurface = new mkcd.BitmapImage({
                 outerMargin: 0,
                 backgroundFill: 'url("#alpha-background")',
                 cellClass: "pixel-cell"
             }, this.state.copy(), [null].concat(this.colors), this.root);
-
+            this.paintSurface.setRootId("sprite-editor-canvas");
 
             this.paintSurface.drag((col, row) => {
-                if (this.activeTool !== PaintTool.Fill) {
-                    this.debug("gesture (" + PaintTool[this.activeTool] + ")");
-                    this.setCell(col, row, this.color, false);
-                }
+                this.debug("gesture (" + PaintTool[this.activeTool] + ")");
+                this.setCell(col, row, this.color, false);
             });
 
             this.paintSurface.up((col, row) => {
-                if (this.activeTool !== PaintTool.Fill) {
-                    this.debug("gesture end (" + PaintTool[this.activeTool] + ")");
-                    this.commit();
-                }
+                this.debug("gesture end (" + PaintTool[this.activeTool] + ")");
+                this.commit();
             });
 
             this.paintSurface.down((col, row) => {
-                if (this.activeTool === PaintTool.Fill) {
-                    this.fill(col, row);
-                }
-                else {
-                    this.setCell(col, row, this.color, false);
-                }
+                this.setCell(col, row, this.color, false);
             });
 
             this.paintSurface.move((col, row) => {
@@ -143,6 +147,7 @@ namespace mkcd {
                 if (this.edit.isStarted) {
                     this.commit();
                 }
+                this.cursorInfo.text("");
             });
 
             this.group.appendChild(this.paintSurface.getView());
@@ -155,13 +160,14 @@ namespace mkcd {
                 optionsMargin: 3,
                 rowMargin: 5
             }, this);
+
             this.palette.setSelected(this.color);
             this.palette.onColorSelected(color => {
                 this.setActiveColor(color);
             });
             this.setActiveColor(this.color);
 
-            // this.debugText = this.group.draw("text").attr({ "font-family": "segoe ui" });
+            this.drawReporterBar();
 
             document.addEventListener("keydown", ev => {
                 if (ev.key === "Undo" || (ev.ctrlKey && ev.key === "z")) {
@@ -209,15 +215,15 @@ namespace mkcd {
             const canvasLeft = paintAreaLeft + CANVAS_HEIGHT / 2 - this.paintSurface.outerWidth() / 2;
             this.paintSurface.translate(canvasLeft, paintAreaTop);
 
+            this.repoterBar.translate(paintAreaLeft, paintAreaTop + CANVAS_HEIGHT + REPORTER_BAR_CANVAS_MARGIN);
+            this.canvasDimensions.at(CANVAS_HEIGHT - this.canvasDimensions.el.getComputedTextLength(), 0);
+
             this.width = paintAreaLeft + CANVAS_HEIGHT + PADDING;
-            this.height = paintAreaTop + CANVAS_HEIGHT + PADDING;
+            this.height = paintAreaTop + CANVAS_HEIGHT + PADDING_BOTTOM + REPORTER_BAR_CANVAS_MARGIN + REPORTER_BAR_HEIGHT;
 
             this.toolbar.translate(PADDING, PADDING);
             this.toolbar.setDimensions(this.width - PADDING * 2, TOOLBAR_HEIGHT);
 
-            if (this.debugText) {
-                this.debugText.at(paintAreaLeft, this.height - PADDING);
-            }
         }
 
         setPreview(preview: BitmapImage, width: number) {
@@ -287,6 +293,7 @@ namespace mkcd {
             this.paintSurface.showOverlay();
             this.preview.restore(this.state, true);
             this.preview.setGridDimensions(this.previewWidth);
+            this.canvasDimensions.text(`${this.columns}x${this.rows}`)
             this.layout();
         }
 
@@ -306,11 +313,29 @@ namespace mkcd {
             return this.height;
         }
 
+        protected drawReporterBar() {
+            this.repoterBar = this.group.group();
+            this.canvasDimensions = this.repoterBar.draw("text")
+                .fontSize(REPORTER_BAR_HEIGHT, svg.LengthUnit.px)
+                .fontFamily("monospace")
+                .fill("white")
+                .alignmentBaseline("hanging")
+                .text(`${this.columns}x${this.rows}`);
+
+            this.cursorInfo = this.repoterBar.draw("text")
+                .fontSize(REPORTER_BAR_HEIGHT, svg.LengthUnit.px)
+                .fontFamily("monospace")
+                .alignmentBaseline("hanging")
+                .fill("white");
+        }
+
         private drawCursor(col: number, row: number) {
             if (this.edit) {
                 this.paintSurface.repaint();
                 this.edit.drawCursor(col, row, (c, r) => this.paintSurface.drawColor(c, r, this.edit.color));
             }
+
+            this.cursorInfo.text(`${col},${row}`);
         }
 
         private paintEdit(edit: Edit) {
@@ -371,48 +396,14 @@ namespace mkcd {
                 case PaintTool.Line: return new LineEdit(this.columns, this.rows, color, this.toolWidth);
                 case PaintTool.Circle: return new CircleEdit(this.columns, this.rows, color, this.toolWidth);
                 case PaintTool.Erase: return new PaintEdit(this.columns, this.rows, 0, this.toolWidth);
-
-                // TODO: Doesn't really need to be a special case
-                case PaintTool.Fill: return undefined;
-            }
-        }
-
-        private fill(col: number, row: number) {
-            const color = this.color;
-            const replColor = this.state.get(col, row);
-            if (replColor === color) {
-                return;
-            }
-
-            this.pushState(true);
-            this.redoStack = [];
-
-            const mask = new mkcd.Bitmask(this.columns, this.rows);
-            mask.set(col, row);
-            const q = [[col, row]];
-            while (q.length) {
-                const [c, r] = q.pop();
-                if (this.state.get(c, r) === replColor) {
-                    this.setCell(c, r, color, true);
-                    tryPush(c + 1, r);
-                    tryPush(c - 1, r);
-                    tryPush(c, r + 1);
-                    tryPush(c, r - 1);
-                }
-            }
-
-            function tryPush(x: number, y: number) {
-                if (x >= 0 && x < mask.width && y >= 0 && y < mask.height && !mask.get(x, y)) {
-                    mask.set(x, y);
-                    q.push([x, y]);
-                }
+                case PaintTool.Fill: return new FillEdit(this.columns, this.rows, color, this.toolWidth);
             }
         }
 
         private debug(msg: string) {
-            if (this.debugText) {
-                this.debugText.text("DEBUG: " + msg);
-            }
+            // if (this.debugText) {
+            //     this.debugText.text("DEBUG: " + msg);
+            // }
         }
 
         private makeTransparencyFill() {

--- a/editor/spriteFieldEditor.ts
+++ b/editor/spriteFieldEditor.ts
@@ -83,11 +83,13 @@ namespace pxt.editor {
                 goog.style.setHeight(contentDiv, null);
                 goog.style.setWidth(contentDiv, null);
                 goog.style.setStyle(contentDiv, "overflow", null);
+                goog.style.setStyle(contentDiv, "max-height", null);
             });
             this.editor.layout();
             goog.style.setHeight(contentDiv, this.editor.outerHeight() + 1);
             goog.style.setWidth(contentDiv, this.editor.outerWidth() + 1);
             goog.style.setStyle(contentDiv, "overflow", "hidden");
+            goog.style.setStyle(contentDiv, "max-height", "500px");
         }
 
 

--- a/editor/spriteFieldEditor.ts
+++ b/editor/spriteFieldEditor.ts
@@ -151,7 +151,7 @@ namespace pxt.editor {
                 outerMargin: 2,
                 cellClass: "pixel-cell"
             }, this.state, [
-                    "rgba(0, 0, 0, 0)",
+                    null,
                     "#ffffff", // white
                     "#33e2e4", // teal
                     "#05b3e0", // blue

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -3,6 +3,7 @@
 
 namespace mkcd {
     import svg = svgUtil;
+    import lf = pxt.Util.lf;
 
     export interface ToolbarProps {
         width: number;
@@ -110,25 +111,30 @@ namespace mkcd {
             }
         }
 
+        resetTool() {
+            this.setTool(0, false);
+        }
+
         protected initTools() {
             this.tools = [
-                { title: "Pencil", tool: PaintTool.Normal, icon: "\uf040" },
-                { title: "Erase", tool: PaintTool.Erase, icon: "\uf12d" },
-                { title: "Fill", tool: PaintTool.Fill, icon: "\uf0d0" },
+                { title: lf("Pencil"), tool: PaintTool.Normal, icon: "\uf040" },
+                { title: lf("Erase"), tool: PaintTool.Erase, icon: "\uf12d" },
+                { title: lf("Fill"), tool: PaintTool.Fill, icon: "\uf0d0" },
                 {
-                    title: "Shapes",
+                    title: lf("Shapes"),
                     tool: PaintTool.Rectangle,
                     icon: "\uf096",
                     options: [
-                        { title: "Rectangle", tool: PaintTool.Rectangle, icon: "\uf096" },
-                        { title: "Line", tool: PaintTool.Line, icon: "\uf07e" },
-                        { title: "Circle", tool: PaintTool.Circle, icon: "\uf10c" },
+                        { title: lf("Rectangle"), tool: PaintTool.Rectangle, icon: "\uf096" },
+                        { title: lf("Line"), tool: PaintTool.Line, icon: "\uf07e" },
+                        { title: lf("Circle"), tool: PaintTool.Circle, icon: "\uf10c" },
                     ]
                 },
             ];
 
             this.toolButtons = this.tools.map((tool, index) => {
                 const toolBtn = this.addButton(tool.icon);
+                toolBtn.title(tool.title);
                 toolBtn.onClick(() => {
                     if (index === this.activeButtonIndex) return;
                     this.setTool(index);
@@ -148,16 +154,19 @@ namespace mkcd {
 
         protected initControls() {
             this.undoButton = this.addButton("\uf0e2");
+            this.undoButton.title(lf("Undo"));
             this.undoButton.onClick(() => {
                 this.host.undo();
             });
 
             this.redoButton = this.addButton("\uf01e");
+            this.redoButton.title(lf("Redo"));
             this.redoButton.onClick(() => {
                 this.host.redo();
             });
 
             this.resizeButton = this.addButton("\uf0b2");
+            this.resizeButton.title(lf("Change sprite size"))
             this.resizeButton.onClick(() => {
                 this.selectedSizePreset = (this.selectedSizePreset + 1) % sizePresets.length;
                 const [width, height] = sizePresets[this.selectedSizePreset];
@@ -169,6 +178,7 @@ namespace mkcd {
             this.cursorSizes = []
             for (let i = 0; i < 3; i++) {
                 const btn = mkCursorSizeButton(i + 1, this.props.height);
+                btn.title(sizeAdjective(i));
                 this.cursorSizes.push(btn);
                 this.optionBar.appendChild(btn.getView());
                 btn.onClick(() => {
@@ -275,6 +285,7 @@ namespace mkcd {
             this.clearOptions();
             this.optionButtons = options.map((option, index) => {
                 const button = mkToolbarButton(option.icon, this.optionsHeight, 2);
+                button.title(option.title);
                 button.onClick(() => {
                     this.setTool(index, true);
                 });
@@ -317,5 +328,15 @@ namespace mkcd {
             backgroundClass: "toolbar-button-background",
             iconClass: "toolbar-button-icon"
         });
+    }
+
+    function sizeAdjective(cursorIndex: number) {
+        switch (cursorIndex) {
+            case 0: return lf("Small Cursor");
+            case 1: return lf("Medium Cursor");
+            case 2: return lf("Large Cursor");
+        }
+
+        return undefined;
     }
 }

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -115,6 +115,14 @@ namespace mkcd {
             this.setTool(0, false);
         }
 
+        setUndoState(enabled: boolean) {
+            this.undoButton.setEnabled(enabled);
+        }
+
+        setRedoState(enabled: boolean) {
+            this.redoButton.setEnabled(enabled);
+        }
+
         protected initTools() {
             this.tools = [
                 { title: lf("Pencil"), tool: PaintTool.Normal, icon: "\uf040" },

--- a/editor/tools.ts
+++ b/editor/tools.ts
@@ -125,6 +125,17 @@ namespace mkcd {
         protected doEditCore(bitmap: Bitmap) {
             const tl = this.topLeft();
             const br = this.bottomRight();
+            for (let i = 0; i < this.toolWidth; i++) {
+                this.drawRectangle(bitmap,
+                    [tl[0] + i, tl[1] + i],
+                    [br[0] - i, br[1] - i]
+                );
+            }
+        }
+
+        protected drawRectangle(bitmap: Bitmap, tl: Coord, br: Coord) {
+            if (tl[0] > br[0] || tl[1] > br[1]) return;
+
             for (let c = tl[0]; c <= br[0]; c++) {
                 bitmap.set(c, tl[1], this.color);
                 bitmap.set(c, br[1], this.color);
@@ -144,15 +155,20 @@ namespace mkcd {
             this.bresenham(this.startCol, this.startRow, this.endCol, this.endRow, bitmap);
         }
 
+        drawCursor(col: number, row: number, draw: (c: number, r: number) => void) {
+            this.drawCore(col, row, draw);
+        }
+
         // https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm
-        private bresenham(x0: number, y0: number, x1: number, y1: number, bitmap: Bitmap) {
+        protected bresenham(x0: number, y0: number, x1: number, y1: number, bitmap: Bitmap) {
             const dx = x1 - x0;
             const dy = y1 - y0;
+            const draw = (c: number, r: number) => bitmap.set(c, r, this.color);
             if (dx === 0) {
                 const startY = dy >= 0 ? y0 : y1;
                 const endY = dy >= 0 ? y1 : y0;
                 for (let y = startY; y <= endY; y++) {
-                    bitmap.set(x0, y, this.color);
+                    this.drawCore(x0, y, draw);
                 }
                 return;
             }
@@ -164,12 +180,26 @@ namespace mkcd {
             let err = 0;
             let y = y0;
             for (let x = x0; x != x1; x += xStep) {
-                bitmap.set(x, y, this.color);
+                this.drawCore(x, y, draw);
                 err += dErr;
                 while (err >= 0.5) {
-                    bitmap.set(x, y, this.color);
+                    this.drawCore(x, y, draw);
                     y += yStep;
                     err -= 1;
+                }
+            }
+        }
+
+        // This is surely not the most efficient approach for drawing thick lines...
+        protected drawCore(col: number, row: number, draw: (c: number, r: number) => void) {
+            col = col - Math.floor(this.toolWidth / 2);
+            row = row - Math.floor(this.toolWidth / 2);
+            for (let i = 0; i < this.toolWidth; i++) {
+                for (let j = 0; j < this.toolWidth; j++) {
+                    const c = col + i;
+                    const r = row + j;
+
+                    draw(c, r);
                 }
             }
         }

--- a/editor/tools.ts
+++ b/editor/tools.ts
@@ -179,11 +179,13 @@ namespace mkcd {
 
             let err = 0;
             let y = y0;
-            for (let x = x0; x != x1; x += xStep) {
+            for (let x = x0; xStep > 0 ? x <= x1 : x >= x1; x += xStep) {
                 this.drawCore(x, y, draw);
                 err += dErr;
                 while (err >= 0.5) {
-                    this.drawCore(x, y, draw);
+                    if (yStep > 0 ? y <= y1 : y >= y1) {
+                        this.drawCore(x, y, draw);
+                    }
                     y += yStep;
                     err -= 1;
                 }

--- a/sim/svg.ts
+++ b/sim/svg.ts
@@ -24,6 +24,7 @@ namespace svgUtil {
 
     export class BaseElement<T extends SVGElement> {
         el: T;
+        protected titleElement: SVGTitleElement;
         constructor(type: string) {
             this.el = elt(type) as T;
         }
@@ -54,6 +55,21 @@ namespace svgUtil {
 
         removeClass(className: string): void {
             this.el.classList.remove(className);
+        }
+
+        title(text: string) {
+            if (!this.titleElement) {
+                this.titleElement = elt("title");
+
+                // Title has to be the first child in the DOM
+                if (this.el.firstChild) {
+                    this.el.insertBefore(this.titleElement, this.el.firstChild)
+                }
+                else {
+                    this.el.appendChild(this.titleElement);
+                }
+            }
+            this.titleElement.textContent = text;
         }
     }
 

--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -47,6 +47,8 @@ div.blocklyTreeRow {
 }
 
 .toolbar-button {
+    cursor: pointer;
+
     .toolbar-button-icon {
         fill: white;
         font-family: "Icons";
@@ -77,8 +79,15 @@ div.blocklyTreeRow {
     stroke-width: 2px;
 }
 
-
 .toolbar-button.toolbar-option-selected .toolbar-button-background {
     stroke: magenta;
     stroke-width: 1px;
+}
+
+#sprite-editor-canvas {
+    cursor: crosshair;
+}
+
+#sprite-editor-palette .palette-swatch {
+    cursor: pointer;
 }

--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -76,3 +76,9 @@ div.blocklyTreeRow {
     stroke: orange;
     stroke-width: 2px;
 }
+
+
+.toolbar-button.toolbar-option-selected .toolbar-button-background {
+    stroke: magenta;
+    stroke-width: 1px;
+}

--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -60,14 +60,22 @@ div.blocklyTreeRow {
     }
 }
 
-.toolbar-button:hover {
+.toolbar-button.disabled {
+    cursor: not-allowed;
+
+    .toolbar-button-background {
+        fill: #aeaeae;
+    }
+}
+
+.toolbar-button:hover:not(.disabled) {
     .toolbar-button-background {
         fill-opacity: 0.9;
         transition: fill-opacity 0.1s;
     }
 }
 
-.toolbar-button:active {
+.toolbar-button:active:not(.disabled) {
     .toolbar-button-background {
         fill-opacity: 1;
         transition: fill-opacity 0.1s;


### PR DESCRIPTION
![sprite_editor_v4](https://user-images.githubusercontent.com/13754588/37941022-b7c2cdfe-3120-11e8-8d13-5f808fe78e70.gif)

Lots of features:

1. Canvas size and cursor position appear below the editor
2. The rectangle button is now a "shapes" button that also has circle and line options
3. Cursors are now centered on the pointer and there are three cursor sizes instead of four
4. Everything in the editor now has tooltips (except the canvas, because that's annoying)
5. Everything in the editor now properly sets the cursor type
6. Undo/redo buttons now disable/enable themselves correctly
7. Editor is bigger
8. Bug fixes, mostly for gestures

Known bugs:

1. Circle tool does not respect cursor width (if anyone has an algorithm for doing that let me know!)
2. Circle tool should really be an ellipse tool...

