### PR TITLE
Adding options to the sprite editor

### DIFF
--- a/editor/buttons.ts
+++ b/editor/buttons.ts
@@ -65,6 +65,10 @@ namespace mkcd {
             }
         }
 
+        public setVisible(visible: boolean) {
+            this.root.setVisible(visible);
+        }
+
         protected buildDom() {
             this.root = new svg.Group();
 

--- a/editor/spriteEditor.ts
+++ b/editor/spriteEditor.ts
@@ -241,16 +241,21 @@ namespace mkcd {
             }
         }
 
-        setActiveColor(color: number) {
-            this.color = color;
-
-            // If the user is erasing, go back to pencil
-            if (this.activeTool === PaintTool.Erase) {
-                this.toolbar.resetTool();
-                this.activeTool = PaintTool.Normal;
+        setActiveColor(color: number, setPalette = false) {
+            if (setPalette) {
+                this.palette.setSelected(color);
             }
+            else {
+                this.color = color;
 
-            this.edit = this.newEdit(this.color);
+                // If the user is erasing, go back to pencil
+                if (this.activeTool === PaintTool.Erase) {
+                    this.toolbar.resetTool();
+                    this.activeTool = PaintTool.Normal;
+                }
+
+                this.edit = this.newEdit(this.color);
+            }
         }
 
         setActiveTool(tool: PaintTool) {
@@ -261,6 +266,12 @@ namespace mkcd {
         setToolWidth(width: number) {
             this.toolWidth = width;
             this.edit = this.newEdit(this.color);
+
+            // Cursor doesn't affect fill, so switch to pencil
+            if (this.activeTool === PaintTool.Fill) {
+                this.toolbar.resetTool();
+                this.activeTool = PaintTool.Normal;
+            }
         }
 
         undo() {
@@ -307,6 +318,10 @@ namespace mkcd {
 
             // Canvas size changed and some edits rely on that (like paint)
             this.edit = this.newEdit(this.color);
+        }
+
+        setSizePresets(presets: [number, number][]) {
+            this.toolbar.setSizePresets(presets);
         }
 
         canvasWidth() {

--- a/editor/spriteFieldEditor.ts
+++ b/editor/spriteFieldEditor.ts
@@ -7,6 +7,24 @@
 namespace pxt.editor {
     import svg = svgUtil;
 
+    export interface FieldSpriteEditorOptions {
+        // Format is semicolon separated pairs, e.g. "width,height;width,height;..."
+        sizes: string;
+
+        // Index of initial color (defaults to 1)
+        initColor: string;
+
+        initWidth: string;
+        initHeight: string;
+    }
+
+    interface ParsedSpriteEditorOptions {
+        sizes: [number, number][];
+        initColor: number;
+        initWidth: number;
+        initHeight: number;
+    }
+
     // It's a square
     const TOTAL_WIDTH = 55;
     const PADDING = 5;
@@ -20,14 +38,18 @@ namespace pxt.editor {
     export class FieldSpriteEditor extends Blockly.Field implements Blockly.FieldCustom {
         public isFieldCustom_ = true;
 
-        private params: any;
+        private params: ParsedSpriteEditorOptions;
         private editor: mkcd.SpriteEditor;
         private preview: mkcd.BitmapImage;
         private state: mkcd.Bitmap;
 
         constructor(text: string, params: any, validator?: Function) {
             super(text, validator);
-            this.params = params;
+            this.params = parseFieldOptions(params);
+
+            if (!this.state) {
+                this.state = new mkcd.Bitmap(this.params.initWidth, this.params.initHeight);
+            }
         }
 
         init() {
@@ -42,7 +64,7 @@ namespace pxt.editor {
             }
 
             if (!this.state) {
-                this.state = new mkcd.Bitmap(16, 16);
+                this.state = new mkcd.Bitmap(this.params.initWidth, this.params.initHeight);
             }
 
             this.redrawPreview();
@@ -71,6 +93,8 @@ namespace pxt.editor {
             this.editor.render(contentDiv);
             this.editor.rePaint();
 
+            this.editor.setActiveColor(this.params.initColor, true);
+            this.editor.setSizePresets(this.params.sizes);
 
             Blockly.DropDownDiv.setColour("#2c3e50", "#2c3e50");
             Blockly.DropDownDiv.showPositionedByBlock(this, this.sourceBlock_, () => {
@@ -226,7 +250,6 @@ namespace pxt.editor {
                 // an empty/invalid sprite and we are converting it to an empty 16x16 sprite
                 // next time the project saves. The best behavior would be to flag this in
                 // the decompiler and return a grey block but that's not supported.
-                this.state = new mkcd.Bitmap(16, 16);
                 return;
             }
 
@@ -243,6 +266,61 @@ namespace pxt.editor {
                     }
                 }
             }
+        }
+    }
+
+    function parseFieldOptions(opts: FieldSpriteEditorOptions) {
+        const parsed: ParsedSpriteEditorOptions = {
+            sizes: [
+                [8, 8],
+                [8, 16],
+                [16, 16],
+                [16, 32],
+                [32, 32],
+            ],
+            initColor: 1,
+            initWidth: 16,
+            initHeight: 16,
+        };
+
+        if (!opts) {
+            return parsed;
+        }
+
+        if (opts.sizes != null) {
+            const pairs = opts.sizes.split(";");
+            const sizes: [number, number][] = [];
+            for (let i = 0; i < pairs.length; i++) {
+                const pair = pairs[i].split(",");
+                if (pair.length !== 2) {
+                    continue;
+                }
+
+                const width = parseInt(pair[0]);
+                const height = parseInt(pair[1]);
+
+                if (isNaN(width) || isNaN(height)) {
+                    continue;
+                }
+
+                sizes.push([width, height]);
+            }
+
+            parsed.sizes = sizes;
+        }
+
+        parsed.initColor = withDefault(opts.initColor, parsed.initColor);
+        parsed.initWidth = withDefault(opts.initWidth, parsed.initWidth);
+        parsed.initHeight = withDefault(opts.initHeight, parsed.initHeight);
+
+        return parsed;
+
+        function withDefault(raw: string, def: number) {
+            const res = parseInt(raw);
+            if (isNaN(res)) {
+                return def;
+            }
+            return res;
         }
     }
 }

--- a/editor/toolbar.ts
+++ b/editor/toolbar.ts
@@ -34,14 +34,6 @@ namespace mkcd {
         options?: ToolOption[];
     }
 
-    const sizePresets: [number, number][] = [
-        [8, 8],
-        [8, 16],
-        [16, 16],
-        [16, 32],
-        [32, 32],
-    ];
-
     // The ratio of the toolbar height that is taken up by the options (as opposed to the buttons)
     const TOOLBAR_OPTIONS_RATIO = 0.333333;
 
@@ -72,22 +64,25 @@ namespace mkcd {
         protected toolbarHeight: number;
         protected optionsHeight: number;
 
+        protected sizePresets: [number, number][];
+
         constructor(protected g: svg.Group, protected props: ToolbarProps, protected host: ToolbarHost) {
             this.toolsBar = g.group();
             this.optionBar = g.group();
             this.dropdownOptions = this.optionBar.group();
 
-            const canvasColumns = this.host.canvasWidth();
-            const canvasRows = this.host.canvasHeight();
-            sizePresets.forEach(([columns, rows], index) => {
-                if (columns === canvasColumns && rows === canvasRows) {
-                    this.selectedSizePreset = index;
-                }
-            });
-
             this.initTools();
             this.initControls();
             this.createOptionsBar();
+
+            this.setSizePresets([
+                [8, 8],
+                [8, 16],
+                [16, 16],
+                [16, 32],
+                [32, 32],
+            ]);
+
             this.layout();
         }
 
@@ -121,6 +116,26 @@ namespace mkcd {
 
         setRedoState(enabled: boolean) {
             this.redoButton.setEnabled(enabled);
+        }
+
+        setSizePresets(presets: [number, number][]) {
+            this.sizePresets = presets;
+
+            if (this.sizePresets && this.sizePresets.length) {
+                const canvasColumns = this.host.canvasWidth();
+                const canvasRows = this.host.canvasHeight();
+
+                this.sizePresets.forEach(([columns, rows], index) => {
+                    if (columns === canvasColumns && rows === canvasRows) {
+                        this.selectedSizePreset = index;
+                    }
+                });
+
+                this.resizeButton.setVisible(true);
+            }
+            else {
+                this.resizeButton.setVisible(false);
+            }
         }
 
         protected initTools() {
@@ -176,8 +191,8 @@ namespace mkcd {
             this.resizeButton = this.addButton("\uf0b2");
             this.resizeButton.title(lf("Change sprite size"))
             this.resizeButton.onClick(() => {
-                this.selectedSizePreset = (this.selectedSizePreset + 1) % sizePresets.length;
-                const [width, height] = sizePresets[this.selectedSizePreset];
+                this.selectedSizePreset = (this.selectedSizePreset + 1) % this.sizePresets.length;
+                const [width, height] = this.sizePresets[this.selectedSizePreset];
                 this.host.resize(width, height);
             });
         }

--- a/sim/svg.ts
+++ b/sim/svg.ts
@@ -71,6 +71,10 @@ namespace svgUtil {
             }
             this.titleElement.textContent = text;
         }
+
+        setVisible(visible: boolean): this {
+            return this.setAttribute("visibility", visible ? "visible" : "hidden");
+        }
     }
 
     export class DrawContext<T extends SVGElement> extends BaseElement<T> {
@@ -246,10 +250,6 @@ namespace svgUtil {
 
         strokeOpacity(opacity: number): this {
             return this.setAttribute("stroke-opacity", opacity);
-        }
-
-        setVisible(visible: boolean): this {
-            return this.setAttribute("visibility", visible ? "visible" : "hidden");
         }
 
         onDown(handler: PointerHandler): this {


### PR DESCRIPTION
New options:

```typescript
    //% img.fieldOptions.initWidth=12
    //% img.fieldOptions.initHeight="13"
    //% img.fieldOptions.initColor=7
    //% img.fieldOptions.sizes="4,4;12,13;45,45"
```

* `initWidth/initHeight` set the initial sprite size
* `initColor` sets the color that is selected in the palette by default 
* `sizes` is a semicolon separated list of size pairs for the resize button. Setting it to empty (e.g. "") will cause the resize button to be hidden

@pelikhan this also fixes the issue you had with changing the cursor size while the fill tool is selected