### PR TITLE
Move blockly toolbox css to semantic.css

### DIFF
--- a/theme/blockly.less
+++ b/theme/blockly.less
@@ -4,32 +4,8 @@
 
 @import 'blockly-core';
 
-div.blocklyTreeRow {
-    margin-bottom: 0px !important;
-    transition-property: background-color;
-    transition-duration: 1s;
-}
-
-.blocklyToolboxDiv, .monacoToolboxDiv {
-    box-shadow: 0 1px 3px rgba(107, 79, 118,0.12), 0 1px 2px rgba(107, 79, 118, 0.24);
-}
-
 .blocklyFlyoutLabelText {
     font-family: @pageFont;
-}
-
-/* Mobile */
-@media only screen and (max-width: @largestMobileScreen) {
-    .blocklyToolboxDiv, .monacoToolboxDiv {
-        border-left: 0 !important;
-    }
-}
-
-/* Tablet */
-@media only screen and (min-width: @tabletBreakpoint) and (max-width: @largestTabletScreen) {
-    .blocklyToolboxDiv, .monacoToolboxDiv {
-        border-left: 0 !important;
-    }
 }
 
 /* Sprite editor */

--- a/theme/style.less
+++ b/theme/style.less
@@ -1,6 +1,7 @@
 /* Import all components */
 @import 'semantic';
 @import 'pxt';
+@import 'blockly-toolbox';
 @import 'themes/default/globals/site.variables';
 @import 'themes/pxt/globals/site.variables';
 @import 'site/globals/site.variables';


### PR DESCRIPTION
Moving Blockly toolbox css to semantic.css as per https://github.com/Microsoft/pxt/pull/4132